### PR TITLE
Shorten scenario names by removing redundant (for ticker) suffix

### DIFF
--- a/src/core/bestMap.ts
+++ b/src/core/bestMap.ts
@@ -2,11 +2,13 @@ import type { BestMap } from "@/types";
 
 function normalizeScenarioText(s: string): string {
   // collapse whitespace, normalize ", " and "[ ... ]" spacing
+  // also strip legacy "(for X)" patterns to support old CSV format during transition
   return s
     .replace(/\s+/g, " ")
     .replace(/\s*,\s*/g, ", ")
     .replace(/\s*\[\s*/g, " [")
     .replace(/\s*\]\s*/g, "]")
+    .replace(/\s*\(for\s+[A-Z0-9_]+\)/gi, "") // strip "(for TICKER)" patterns
     .trim();
 }
 

--- a/src/core/scenario.ts
+++ b/src/core/scenario.ts
@@ -17,9 +17,9 @@ export function composeScenario(
     return base + `Buy ${branch.inputTicker}`;
   }
 
-  // MAKE: 'Make <recipeLabel> (for X)' + optional ' [childScenario]'
+  // MAKE: 'Make <recipeLabel>' + optional ' [childScenario]'
   const label = branch.recipeLabel ?? branch.inputTicker;
-  const core = `Make ${label} (for ${branch.inputTicker})`;
+  const core = `Make ${label}`;
   const suffix = branch.childScenario && branch.childScenario.trim().length
     ? ` [${branch.childScenario}]`
     : "";


### PR DESCRIPTION
## Summary
- Remove redundant `(for TICKER)` suffix from MAKE scenario names
- Recipe IDs already indicate what's being produced, making this suffix unnecessary
- Significantly reduces scenario name length while maintaining full specificity

## Changes
- **src/core/scenario.ts**: Updated `composeScenario()` to generate format `"Make HCP_2"` instead of `"Make HCP_2 (for HCP)"`
- **src/core/bestMap.ts**: Updated `normalizeScenarioText()` to strip legacy `(for X)` patterns during matching, ensuring backward compatibility with existing BestRecipeIDs CSV during transition

## Example
**Before**: `Make HCP_2 (for HCP), Buy FOD, Make 2x2P-1 (for PE) [Buy BWO, Buy O]`  
**After**: `Make HCP_2, Buy FOD, Make 2x2P-1 [Buy BWO, Buy O]`

## Compatibility
The normalization logic supports both old and new formats, so the app will continue to match scenarios correctly even if the BestRecipeIDs CSV hasn't been updated yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)