### PR TITLE
Expand top options table from 5 to 20 entries

### DIFF
--- a/app/components/ReportClient.tsx
+++ b/app/components/ReportClient.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useMemo, useState } from "react";
 import type { PriceMode } from "@/types";
 import BestScenarioSankey from "./BestScenarioSankey";
-import Top5Table from "./Top5Table";
+import Top20Table from "./Top20Table";
 import { scenarioDisplayName } from "@/core/scenario";
 
 type ApiReport = {
@@ -15,7 +15,7 @@ type ApiReport = {
   totalOptions: number;
   bestPA: number | null;
   best: any;
-  top5: any[];
+  top20: any[];
 };
 
 export default function ReportClient() {
@@ -263,11 +263,11 @@ export default function ReportClient() {
             zIndex: 2,
             paddingTop: "0px"
           }}>
-            <h2>Top 5 Options</h2>
+            <h2>Top Options</h2>
             <p style={{ margin: "8px 0 16px", color: "#555", maxWidth: 760 }}>
-              List of top other production scenarios ranked by profit per area.
+              List of up to 20 other production scenarios ranked by profit per area.
             </p>
-            <Top5Table options={report.top5} priceMode={report.priceMode} />
+            <Top20Table options={report.top20} priceMode={report.priceMode} />
           </section>
         )}
       </div>

--- a/app/components/Top20Table.tsx
+++ b/app/components/Top20Table.tsx
@@ -1,11 +1,11 @@
-// app/components/Top5Table.tsx
+// app/components/Top20Table.tsx
 "use client";
 
 import React, { useState } from "react";
 import { scenarioDisplayName } from "@/core/scenario";
 import BestScenarioSankey from "./BestScenarioSankey";
 
-type Top5Option = {
+type Top20Option = {
   ticker: string;
   recipeId: string | null;
   scenario: string;
@@ -15,7 +15,7 @@ type Top5Option = {
   totalProfitPA?: number;
 };
 
-export default function Top5Table({ options, priceMode }: { options: Top5Option[]; priceMode?: string }) {
+export default function Top20Table({ options, priceMode }: { options: Top20Option[]; priceMode?: string }) {
   const [expandedRows, setExpandedRows] = useState<Set<number>>(new Set());
 
   if (!options || options.length === 0) return null;
@@ -75,21 +75,25 @@ export default function Top5Table({ options, priceMode }: { options: Top5Option[
                   }}
                 >
                   <td style={{ padding: "8px", border: "1px solid #dee2e6", textAlign: "center" }}>
-                    <button
-                      onClick={() => toggleRow(index)}
-                      style={{
-                        padding: "4px 12px",
-                        cursor: "pointer",
-                        backgroundColor: "#2563eb",
-                        color: "white",
-                        border: "none",
-                        borderRadius: "4px",
-                        fontSize: "12px",
-                        fontWeight: 600
-                      }}
-                    >
-                      {expandedRows.has(index) ? "−" : "+"}
-                    </button>
+                    {index === 0 ? (
+                      <span style={{ color: "#6b7280", fontSize: "12px" }}>See Above</span>
+                    ) : (
+                      <button
+                        onClick={() => toggleRow(index)}
+                        style={{
+                          padding: "4px 12px",
+                          cursor: "pointer",
+                          backgroundColor: "#2563eb",
+                          color: "white",
+                          border: "none",
+                          borderRadius: "4px",
+                          fontSize: "12px",
+                          fontWeight: 600
+                        }}
+                      >
+                        {expandedRows.has(index) ? "−" : "+"}
+                      </button>
+                    )}
                   </td>
                   <td style={{ padding: "8px", border: "1px solid #dee2e6", textAlign: "center" }}>{option.ticker}</td>
                   <td style={{ padding: "8px", border: "1px solid #dee2e6", textAlign: "center" }}>{option.recipeId || "—"}</td>

--- a/src/server/report.ts
+++ b/src/server/report.ts
@@ -33,7 +33,7 @@ export async function buildReport(opts: {
       bestPA: null,
       bestScenario: "",
       best: null,
-      top5: [],
+      top20: [],
     };
   }
 
@@ -70,8 +70,8 @@ export async function buildReport(opts: {
     bestRows.push(["Input Payback (7d buffer) [days]:", ip.days ?? "n/a"]);
   }
 
-  // Top 5 summary: include ROI only (no rows here)
-  const top5: Array<WithMetrics<typeof ranked[number]["o"]>> = ranked.slice(0, 5).map(({ o, r }) => {
+  // Top 20 summary: include ROI only (no rows here)
+  const top20: Array<WithMetrics<typeof ranked[number]["o"]>> = ranked.slice(0, 20).map(({ o, r }) => {
     const roi = computeRoiNarrow(o);
     return {
       ...o,
@@ -89,6 +89,6 @@ export async function buildReport(opts: {
     bestPA: best.r.subtreeProfitPerArea ?? null,
     bestScenario: best.o.scenario ?? "",
     best: includeRows ? { ...bestRaw, rows: bestRows } : bestRaw,
-    top5,
+    top20,
   };
 }


### PR DESCRIPTION
## Summary
- Renamed `Top5Table` component to `Top20Table` to display up to 20 top production scenarios
- Updated the backend to return `top20` instead of `top5` options
- Modified the UI to show "Top Options" instead of "Top 5 Options"
- Added "See Above" text for the first row's expand button to avoid duplicate Sankey diagram

## Test plan
- [ ] Verify the table now displays up to 20 options (when available)
- [ ] Check that the first row shows "See Above" instead of an expand button
- [ ] Confirm other rows can still expand to show individual Sankey diagrams
- [ ] Ensure profit calculations are correct across all displayed options

🤖 Generated with [Claude Code](https://claude.com/claude-code)