### PR TITLE
Fix best-recipes using stale test data instead of production files

### DIFF
--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -16,8 +16,15 @@ export const LOCAL_DATA_SOURCES = {
 function getFileSuffix(): string {
   // In production (main branch), use no suffix
   // In preview deployments (other branches), use -test suffix
-  const isProduction = process.env.VERCEL_ENV === 'production' ||
-                       process.env.VERCEL_GIT_COMMIT_REF === 'main';
+
+  // Check Vercel environment
+  const isVercelProduction = process.env.VERCEL_ENV === 'production' ||
+                             process.env.VERCEL_GIT_COMMIT_REF === 'main';
+
+  // Check GitHub Actions environment
+  const isGitHubMain = process.env.GITHUB_REF === 'refs/heads/main';
+
+  const isProduction = isVercelProduction || isGitHubMain;
   return isProduction ? '' : '-test';
 }
 


### PR DESCRIPTION
## Problem

Best-recipes generation was producing results that differed significantly from main page analysis, especially visible in buy-all sourcing scenarios. The discrepancies were caused by best-recipes using outdated data instead of current dynamic exchange-specific costs.

## Root Cause

The `getFileSuffix()` function in `src/lib/config.ts` only checked Vercel environment variables to determine production vs test mode:
- `VERCEL_ENV === 'production'`
- `VERCEL_GIT_COMMIT_REF === 'main'`

**When GitHub Actions runs the best-recipes generation workflow**, these Vercel variables don't exist, so `getFileSuffix()` always returned `-test`, causing it to load:
- ❌ `recipes-test.csv` (potentially stale/outdated)
- ❌ `prices-test.csv` (potentially stale/outdated)

Instead of the production files with current data:
- ✅ `recipes.csv` (current WfCst-ANT, Deprec-ANT, AllBuildCst-ANT, etc.)
- ✅ `prices.csv` (current market prices)

This caused the best-recipes results to use old workforce costs, depreciation values, and building costs, leading to incorrect profit calculations that didn't match the main page analysis.

## Solution

Added GitHub Actions environment detection by checking `GITHUB_REF === 'refs/heads/main'`:

```typescript
function getFileSuffix(): string {
  // Check Vercel environment
  const isVercelProduction = process.env.VERCEL_ENV === 'production' ||
                             process.env.VERCEL_GIT_COMMIT_REF === 'main';

  // Check GitHub Actions environment
  const isGitHubMain = process.env.GITHUB_REF === 'refs/heads/main';

  const isProduction = isVercelProduction || isGitHubMain;
  return isProduction ? '' : '-test';
}
```

## Behavior After Fix

| Environment | Suffix | Files Used |
|-------------|--------|------------|
| Vercel Production | `` | recipes.csv, prices.csv |
| Vercel main preview | `` | recipes.csv, prices.csv |
| **GitHub Actions main** | `` | **recipes.csv, prices.csv** ✅ FIXED |
| GitHub Actions branch | `-test` | recipes-test.csv, prices-test.csv |
| Vercel other branches | `-test` | recipes-test.csv, prices-test.csv |

## Impact

- ✅ Best-recipes will now use current dynamic exchange-specific costs (WfCst-ANT, Deprec-ANT, etc.)
- ✅ Results will match main page analysis calculations
- ✅ Buy-all profit calculations will be accurate
- ✅ Automatic regeneration every hour will use fresh data
- ✅ Test infrastructure (non-main branches) continues to work correctly

## Testing

After merge, the `refresh-best-recipes-gcs.yml` workflow will automatically run and regenerate best-recipes.json with the correct production data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)