### PR TITLE
Add retry logic for transient socket errors in CSV fetching

### DIFF
--- a/scripts/calculate-dynamic-costs.ts
+++ b/scripts/calculate-dynamic-costs.ts
@@ -2,6 +2,7 @@ import { config } from "dotenv";
 import { parse } from "csv-parse/sync";
 import { stringify } from "csv-stringify/sync";
 import { writeFileSync } from "fs";
+import { fetchWithRetry } from "../src/lib/csvFetch";
 
 // Load environment variables from .env.local
 config({ path: ".env.local" });
@@ -117,11 +118,7 @@ interface PriceRow {
 
 async function fetchCsvText(url: string): Promise<string> {
   console.log(`Fetching ${url}...`);
-  const response = await fetch(url);
-  if (!response.ok) {
-    throw new Error(`Failed to fetch ${url}: ${response.statusText}`);
-  }
-  return await response.text();
+  return fetchWithRetry(url);
 }
 
 type Exchange = "ANT" | "CIS" | "ICA" | "NCC" | "UNV";

--- a/scripts/calculate-expanded-costs.ts
+++ b/scripts/calculate-expanded-costs.ts
@@ -2,6 +2,7 @@ import { config } from "dotenv";
 import { parse } from "csv-parse/sync";
 import { stringify } from "csv-stringify/sync";
 import { writeFileSync } from "fs";
+import { fetchWithRetry } from "../src/lib/csvFetch";
 
 // Load environment variables from .env.local
 config({ path: ".env.local" });
@@ -155,12 +156,7 @@ interface PriceRow {
 async function fetchCsvText(url: string): Promise<string | null> {
   console.log(`Fetching ${url}...`);
   try {
-    const response = await fetch(url);
-    if (!response.ok) {
-      console.warn(`  Warning: Failed to fetch ${url}: ${response.statusText}`);
-      return null;
-    }
-    return await response.text();
+    return await fetchWithRetry(url);
   } catch (error) {
     console.warn(`  Warning: Error fetching ${url}:`, error);
     return null;

--- a/scripts/classify-production-volume.ts
+++ b/scripts/classify-production-volume.ts
@@ -2,6 +2,7 @@ import { writeFileSync, mkdirSync } from "fs";
 import { execSync } from "child_process";
 import { parse } from "csv-parse/sync";
 import { stringify } from "csv-stringify/sync";
+import { fetchWithRetry } from "../src/lib/csvFetch";
 
 /**
  * Production Volume Classification Script
@@ -120,11 +121,7 @@ async function classifyProductionVolume(dryRun: boolean, regionName: string) {
 
   // Step 1: Fetch input CSV
   console.log("📥 Fetching static production volume CSV...");
-  const csvResponse = await fetch(regionConfig.staticCsvUrl);
-  if (!csvResponse.ok) {
-    throw new Error(`Failed to fetch static CSV: ${csvResponse.status} ${csvResponse.statusText}`);
-  }
-  const csvText = await csvResponse.text();
+  const csvText = await fetchWithRetry(regionConfig.staticCsvUrl);
 
   const rows: InputRow[] = parse(csvText, {
     columns: true,

--- a/scripts/merge-prices.ts
+++ b/scripts/merge-prices.ts
@@ -1,6 +1,7 @@
 import { writeFileSync } from "fs";
 import { parse } from "csv-parse/sync";
 import { stringify } from "csv-stringify/sync";
+import { fetchWithRetry } from "../src/lib/csvFetch";
 
 // API endpoints
 const FNAR_API = "https://rest.fnar.net/csv/prices";
@@ -31,11 +32,7 @@ const EXCHANGE_PREFIX_MAP: Record<string, string> = {
 
 async function fetchCsvText(url: string): Promise<string> {
   console.log(`Fetching ${url}...`);
-  const response = await fetch(url);
-  if (!response.ok) {
-    throw new Error(`Failed to fetch ${url}: ${response.statusText}`);
-  }
-  return await response.text();
+  return fetchWithRetry(url);
 }
 
 async function main() {

--- a/src/lib/csvFetch.ts
+++ b/src/lib/csvFetch.ts
@@ -5,7 +5,7 @@ import { join } from "path";
 // In-memory cache for serverless functions (persists across invocations in same container)
 const csvCache = new Map<string, Array<Record<string, any>>>();
 
-async function fetchWithRetry(url: string, maxAttempts = 4): Promise<string> {
+export async function fetchWithRetry(url: string, maxAttempts = 4): Promise<string> {
   let lastError: unknown;
   for (let attempt = 1; attempt <= maxAttempts; attempt++) {
     try {

--- a/src/lib/csvFetch.ts
+++ b/src/lib/csvFetch.ts
@@ -5,27 +5,33 @@ import { join } from "path";
 // In-memory cache for serverless functions (persists across invocations in same container)
 const csvCache = new Map<string, Array<Record<string, any>>>();
 
+class HttpError extends Error {
+  constructor(public status: number, message: string) {
+    super(message);
+    this.name = "HttpError";
+  }
+}
+
 export async function fetchWithRetry(url: string, maxAttempts = 4): Promise<string> {
   let lastError: unknown;
   for (let attempt = 1; attempt <= maxAttempts; attempt++) {
-    let res: Response;
     try {
-      res = await fetch(url, { cache: "no-store" });
+      const res = await fetch(url, { cache: "no-store" });
+      // HTTP errors are not transient — throw immediately without retrying
+      if (!res.ok) {
+        throw new HttpError(res.status, `CSV fetch failed: ${res.status} ${res.statusText} for URL: ${url}`);
+      }
+      return await res.text();
     } catch (err) {
-      // Only network/socket errors (TypeError) reach here — retry these
+      if (err instanceof HttpError) throw err;
+      // Network/socket errors and body-read failures are retried
       lastError = err;
       if (attempt < maxAttempts) {
         const delayMs = 1000 * Math.pow(2, attempt - 1); // 1s, 2s, 4s
         console.warn(`[csvFetch] Attempt ${attempt} failed for ${url}: ${(err as Error).message}. Retrying in ${delayMs}ms...`);
         await new Promise(resolve => setTimeout(resolve, delayMs));
       }
-      continue;
     }
-    // HTTP errors are not transient — throw immediately without retrying
-    if (!res.ok) {
-      throw new Error(`CSV fetch failed: ${res.status} ${res.statusText} for URL: ${url}`);
-    }
-    return await res.text();
   }
   throw lastError;
 }

--- a/src/lib/csvFetch.ts
+++ b/src/lib/csvFetch.ts
@@ -8,20 +8,24 @@ const csvCache = new Map<string, Array<Record<string, any>>>();
 export async function fetchWithRetry(url: string, maxAttempts = 4): Promise<string> {
   let lastError: unknown;
   for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    let res: Response;
     try {
-      const res = await fetch(url, { cache: "no-store" });
-      if (!res.ok) {
-        throw new Error(`CSV fetch failed: ${res.status} ${res.statusText} for URL: ${url}`);
-      }
-      return await res.text();
+      res = await fetch(url, { cache: "no-store" });
     } catch (err) {
+      // Only network/socket errors (TypeError) reach here — retry these
       lastError = err;
       if (attempt < maxAttempts) {
         const delayMs = 1000 * Math.pow(2, attempt - 1); // 1s, 2s, 4s
         console.warn(`[csvFetch] Attempt ${attempt} failed for ${url}: ${(err as Error).message}. Retrying in ${delayMs}ms...`);
         await new Promise(resolve => setTimeout(resolve, delayMs));
       }
+      continue;
     }
+    // HTTP errors are not transient — throw immediately without retrying
+    if (!res.ok) {
+      throw new Error(`CSV fetch failed: ${res.status} ${res.statusText} for URL: ${url}`);
+    }
+    return await res.text();
   }
   throw lastError;
 }


### PR DESCRIPTION
## Summary

- Adds `fetchWithRetry` to `src/lib/csvFetch.ts` with exponential backoff (1s, 2s, 4s, up to 4 attempts) to handle transient socket errors when fetching CSVs from GCS
- Replaces inline `fetch()` calls in all 4 CSV-fetching scripts with the shared `fetchWithRetry`
- Only retries on network/socket errors (TypeError); HTTP errors (4xx/5xx) fail immediately without retrying
- Changes `refresh-best-recipes-gcs.yml` to run hourly but only save historical snapshots every 8 hours (at 00:xx, 08:xx, 16:xx UTC)

## Test plan

- [ ] Verify scripts still fetch and process CSVs correctly on a clean run
- [ ] Confirm a transient socket error causes a retry with logged warning
- [ ] Confirm a 404/403 HTTP error fails immediately (no retries)
- [ ] Verify the workflow saves snapshots only at hours 0, 8, 16 and skips index updates on other hours

🤖 Generated with [Claude Code](https://claude.com/claude-code)