### PR TITLE
Add Planet Repair Tracker tool

### DIFF
--- a/app/api/planet-repairs/route.ts
+++ b/app/api/planet-repairs/route.ts
@@ -1,0 +1,111 @@
+import { NextResponse } from "next/server";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
+const FIO_BASE = "https://rest.fnar.net";
+
+const ALLOWED_TICKERS = new Set([
+  "AAF", "AML", "APF", "ASM", "BMP", "CHP", "CLF", "CLR", "COL", "DRS",
+  "ECA", "EDM", "EEP", "ELP", "EXT", "FER", "FP", "FRM", "FS", "GF",
+  "HWP", "HYF", "INC", "IVP", "LAB", "MCA", "ORC", "PAC", "PHF", "POL",
+  "PP1", "PP2", "PP3", "PP4", "PPF", "REF", "RIG", "SCA", "SD", "SE",
+  "SKF", "SL", "SME", "SPF", "SPP", "TNP", "UPF", "WEL", "WPL",
+]);
+
+interface BuildingEntry {
+  NaturalId: string;
+  Ticker: string;
+  Condition: number;
+}
+
+interface PlanetEntry {
+  NaturalId: string;
+  PlanetName: string;
+}
+
+export interface PlanetRepairInfo {
+  planetId: string;
+  planetName: string;
+  minCondition: number;
+  daysSinceRepair: number;
+}
+
+function daysSinceLastRepair(condition: number): number {
+  const K = 1789 / 25000;
+  const FLOOR = 0.33;
+  const RANGE = 0.67;
+  const INFLECTION = 100.87;
+  const numerator = RANGE / (condition - FLOOR) - 1;
+  return (1 / K) * Math.log(numerator) + INFLECTION;
+}
+
+export async function GET(request: Request) {
+  const username = request.headers.get("x-fio-username");
+  const apiKey = request.headers.get("x-fio-api-key");
+
+  if (!username || !apiKey) {
+    return NextResponse.json(
+      { error: "FIO username and API key are required." },
+      { status: 400 }
+    );
+  }
+
+  try {
+    const [buildingsRes, planetsRes] = await Promise.all([
+      fetch(`${FIO_BASE}/rain/userplanetbuildings/${encodeURIComponent(username)}`, {
+        headers: { accept: "application/json", Authorization: apiKey },
+      }),
+      fetch(`${FIO_BASE}/planet/allplanets`, {
+        headers: { accept: "application/json" },
+      }),
+    ]);
+
+    if (!buildingsRes.ok) {
+      return NextResponse.json(
+        { error: `FIO API error: ${buildingsRes.status} ${buildingsRes.statusText}` },
+        { status: 502 }
+      );
+    }
+
+    const buildings: BuildingEntry[] = await buildingsRes.json();
+
+    const planetNameMap = new Map<string, string>();
+    if (planetsRes.ok) {
+      const allPlanets: PlanetEntry[] = await planetsRes.json();
+      for (const p of allPlanets) {
+        planetNameMap.set(p.NaturalId, p.PlanetName);
+      }
+    }
+
+    // Group by planet, track minimum condition per planet
+    const planetMinCondition = new Map<string, number>();
+    for (const b of buildings) {
+      if (!ALLOWED_TICKERS.has(b.Ticker)) continue;
+      const current = planetMinCondition.get(b.NaturalId);
+      if (current === undefined || b.Condition < current) {
+        planetMinCondition.set(b.NaturalId, b.Condition);
+      }
+    }
+
+    const results: PlanetRepairInfo[] = [];
+    for (const [planetId, minCondition] of planetMinCondition.entries()) {
+      // Guard against condition at or below FLOOR (formula blows up)
+      if (minCondition <= 0.33) continue;
+      results.push({
+        planetId,
+        planetName: planetNameMap.get(planetId) ?? planetId,
+        minCondition,
+        daysSinceRepair: daysSinceLastRepair(minCondition),
+      });
+    }
+
+    results.sort((a, b) => b.daysSinceRepair - a.daysSinceRepair);
+
+    return NextResponse.json({ planets: results });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Unknown error";
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/app/planet-repairs/PlanetRepairsClient.tsx
+++ b/app/planet-repairs/PlanetRepairsClient.tsx
@@ -1,0 +1,331 @@
+"use client";
+
+import { useState, useCallback } from "react";
+import { usePersistedSettings } from "@/hooks/usePersistedSettings";
+
+interface PlanetRepairInfo {
+  planetId: string;
+  planetName: string;
+  minCondition: number;
+  daysSinceRepair: number;
+}
+
+interface ApiResponse {
+  planets: PlanetRepairInfo[];
+  error?: string;
+}
+
+type SortField = "planetId" | "daysSinceRepair";
+
+export default function PlanetRepairsClient() {
+  const [planets, setPlanets] = useState<PlanetRepairInfo[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [lastRefresh, setLastRefresh] = useState<Date | null>(null);
+  const [sortField, setSortField] = useState<SortField>("daysSinceRepair");
+  const [sortAsc, setSortAsc] = useState(false);
+  // Draft values while typing — committed on blur/Enter
+  const [draftAges, setDraftAges] = useState<Record<string, string>>({});
+
+  const [fioUsername, setFioUsername] = usePersistedSettings<string>(
+    "prun:fio:username",
+    "",
+    { updateUrl: false }
+  );
+  const [fioApiKey, setFioApiKey] = usePersistedSettings<string>(
+    "prun:fio:apiKey",
+    "",
+    { updateUrl: false }
+  );
+  const [targetAges, setTargetAges] = usePersistedSettings<Record<string, number>>(
+    "prun:repairs:targetAges",
+    {},
+    {
+      updateUrl: false,
+      serialize: (val) => JSON.stringify(val),
+      deserialize: (str) => {
+        try {
+          return JSON.parse(str) as Record<string, number>;
+        } catch {
+          return null;
+        }
+      },
+    }
+  );
+
+  const hasCredentials = fioUsername.trim() !== "" && fioApiKey.trim() !== "";
+
+  const fetchData = useCallback(async () => {
+    if (!fioUsername.trim() || !fioApiKey.trim()) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/planet-repairs", {
+        headers: {
+          "x-fio-username": fioUsername.trim(),
+          "x-fio-api-key": fioApiKey.trim(),
+        },
+      });
+      const json: ApiResponse = await res.json();
+      if (json.error) {
+        setError(json.error);
+      } else {
+        setPlanets(json.planets);
+        setLastRefresh(new Date());
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to fetch data");
+    } finally {
+      setLoading(false);
+    }
+  }, [fioUsername, fioApiKey]);
+
+  const handleSort = (field: SortField) => {
+    if (sortField === field) {
+      setSortAsc(!sortAsc);
+    } else {
+      setSortField(field);
+      setSortAsc(field === "planetId");
+    }
+  };
+
+  // While typing: only update the draft display value
+  const handleDraftChange = (planetId: string, value: string) => {
+    setDraftAges((prev) => ({ ...prev, [planetId]: value }));
+  };
+
+  // On blur or Enter: commit the draft to targetAges
+  const commitTargetAge = (planetId: string, value: string) => {
+    const num = value.trim() === "" ? undefined : Number(value);
+    const updated = { ...targetAges };
+    if (num === undefined || isNaN(num)) {
+      delete updated[planetId];
+    } else {
+      updated[planetId] = num;
+    }
+    setTargetAges(updated);
+    // Clear draft so the input reflects the committed value
+    setDraftAges((prev) => {
+      const next = { ...prev };
+      delete next[planetId];
+      return next;
+    });
+  };
+
+  const inputValue = (planetId: string) =>
+    planetId in draftAges
+      ? draftAges[planetId]
+      : (targetAges[planetId]?.toString() ?? "");
+
+  // Split into alert vs. normal using committed targetAges only
+  const alertPlanets = planets
+    .filter((p) => {
+      const target = targetAges[p.planetId];
+      return target !== undefined && p.daysSinceRepair >= target - 10;
+    })
+    .sort((a, b) => {
+      const aUrgency = a.daysSinceRepair - (targetAges[a.planetId] ?? 0);
+      const bUrgency = b.daysSinceRepair - (targetAges[b.planetId] ?? 0);
+      return bUrgency - aUrgency;
+    });
+
+  const normalPlanets = planets.filter((p) => {
+    const target = targetAges[p.planetId];
+    return target === undefined || p.daysSinceRepair < target - 10;
+  });
+
+  const sortedNormal = [...normalPlanets].sort((a, b) => {
+    if (sortField === "planetId") {
+      return sortAsc
+        ? a.planetId.localeCompare(b.planetId)
+        : b.planetId.localeCompare(a.planetId);
+    }
+    const diff = a.daysSinceRepair - b.daysSinceRepair;
+    return sortAsc ? diff : -diff;
+  });
+
+  const sortIndicator = (field: SortField) =>
+    sortField === field ? (sortAsc ? " ▲" : " ▼") : "";
+
+  const formatDays = (days: number) => days.toFixed(1);
+
+  const daysUntilTarget = (p: PlanetRepairInfo) => {
+    const target = targetAges[p.planetId];
+    if (target === undefined) return "—";
+    const remaining = target - p.daysSinceRepair;
+    return remaining >= 0
+      ? `${remaining.toFixed(1)}d`
+      : `${Math.abs(remaining).toFixed(1)}d overdue`;
+  };
+
+  const urgencyClass = (p: PlanetRepairInfo) => {
+    const target = targetAges[p.planetId];
+    if (target === undefined) return "";
+    if (p.daysSinceRepair >= target) return "status-error";
+    return "status-warning";
+  };
+
+  const targetInput = (planetId: string) => (
+    <input
+      className="terminal-input"
+      type="text"
+      inputMode="numeric"
+      value={inputValue(planetId)}
+      onChange={(e) => handleDraftChange(planetId, e.target.value)}
+      onBlur={(e) => commitTargetAge(planetId, e.target.value)}
+      onKeyDown={(e) => {
+        if (e.key === "Enter") commitTargetAge(planetId, (e.target as HTMLInputElement).value);
+      }}
+      style={{ width: 80, textAlign: "right", padding: "2px 6px" }}
+    />
+  );
+
+  return (
+    <div style={{ maxWidth: 900, margin: "0 auto" }}>
+      <h1 className="terminal-header" style={{ marginBottom: "1.5rem" }}>
+        Planet Repair Tracker
+      </h1>
+
+      {/* Credentials */}
+      <div className="terminal-box" style={{ marginBottom: "1.5rem" }}>
+        <div style={{ marginBottom: "0.75rem", fontWeight: 600, color: "var(--color-accent-primary)" }}>
+          FIO Credentials
+        </div>
+        <div style={{ display: "flex", gap: "0.75rem", flexWrap: "wrap", alignItems: "flex-end" }}>
+          <div style={{ display: "flex", flexDirection: "column", gap: "0.25rem" }}>
+            <label style={{ fontSize: "0.75rem", color: "var(--color-text-muted)" }}>Username</label>
+            <input
+              className="terminal-input"
+              type="text"
+              value={fioUsername}
+              onChange={(e) => setFioUsername(e.target.value)}
+              placeholder="FIO username"
+              style={{ minWidth: 180 }}
+            />
+          </div>
+          <div style={{ display: "flex", flexDirection: "column", gap: "0.25rem" }}>
+            <label style={{ fontSize: "0.75rem", color: "var(--color-text-muted)" }}>API Key</label>
+            <input
+              className="terminal-input"
+              type="password"
+              value={fioApiKey}
+              onChange={(e) => setFioApiKey(e.target.value)}
+              placeholder="FIO API key"
+              style={{ minWidth: 260 }}
+            />
+          </div>
+          <button
+            className="terminal-button"
+            onClick={fetchData}
+            disabled={loading || !hasCredentials}
+          >
+            {loading ? "Loading..." : "Fetch Data"}
+          </button>
+        </div>
+        {!hasCredentials && (
+          <div style={{ marginTop: "0.5rem", fontSize: "0.8rem", color: "var(--color-text-muted)" }}>
+            Enter your FIO username and API key to fetch planet building data.
+          </div>
+        )}
+        {lastRefresh && (
+          <div style={{ marginTop: "0.5rem", fontSize: "0.8rem", color: "var(--color-text-muted)" }}>
+            Last refreshed: {lastRefresh.toLocaleTimeString()}
+          </div>
+        )}
+      </div>
+
+      {error && (
+        <div className="terminal-box status-error" style={{ marginBottom: "1.5rem" }}>
+          Error: {error}
+        </div>
+      )}
+
+      {loading && (
+        <div className="terminal-loading" style={{ marginBottom: "1.5rem" }}>
+          Fetching building data...
+        </div>
+      )}
+
+      {planets.length > 0 && (
+        <>
+          {/* Alert section */}
+          {alertPlanets.length > 0 && (
+            <div className="terminal-box" style={{ marginBottom: "1.5rem", borderColor: "var(--color-status-error, #ff4444)" }}>
+              <div style={{ marginBottom: "0.75rem", fontWeight: 600, color: "var(--color-status-error, #ff4444)" }}>
+                Approaching Repair Target ({alertPlanets.length} planet{alertPlanets.length !== 1 ? "s" : ""})
+              </div>
+              <table className="terminal-table" style={{ width: "100%" }}>
+                <thead>
+                  <tr>
+                    <th style={{ textAlign: "left" }}>Planet</th>
+                    <th style={{ textAlign: "right" }}>Days Since Repair</th>
+                    <th style={{ textAlign: "right" }}>Target Age (days)</th>
+                    <th style={{ textAlign: "right" }}>Status</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {alertPlanets.map((p) => (
+                    <tr key={p.planetId}>
+                      <td>{p.planetName}</td>
+                      <td style={{ textAlign: "right" }} className={urgencyClass(p)}>
+                        {formatDays(p.daysSinceRepair)}
+                      </td>
+                      <td style={{ textAlign: "right" }}>{targetInput(p.planetId)}</td>
+                      <td style={{ textAlign: "right" }} className={urgencyClass(p)}>
+                        {daysUntilTarget(p)}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+
+          {/* All planets section */}
+          <div className="terminal-box">
+            <div style={{ marginBottom: "0.75rem", fontWeight: 600, color: "var(--color-accent-primary)" }}>
+              All Planets ({sortedNormal.length})
+            </div>
+            <table className="terminal-table" style={{ width: "100%" }}>
+              <thead>
+                <tr>
+                  <th
+                    style={{ textAlign: "left", cursor: "pointer" }}
+                    onClick={() => handleSort("planetId")}
+                  >
+                    Planet{sortIndicator("planetId")}
+                  </th>
+                  <th
+                    style={{ textAlign: "right", cursor: "pointer" }}
+                    onClick={() => handleSort("daysSinceRepair")}
+                  >
+                    Days Since Repair{sortIndicator("daysSinceRepair")}
+                  </th>
+                  <th style={{ textAlign: "right" }}>Target Age (days)</th>
+                </tr>
+              </thead>
+              <tbody>
+                {sortedNormal.map((p) => (
+                  <tr key={p.planetId}>
+                    <td>{p.planetName}</td>
+                    <td style={{ textAlign: "right" }}>
+                      {formatDays(p.daysSinceRepair)}
+                    </td>
+                    <td style={{ textAlign: "right" }}>{targetInput(p.planetId)}</td>
+                  </tr>
+                ))}
+                {sortedNormal.length === 0 && (
+                  <tr>
+                    <td colSpan={3} style={{ textAlign: "center", color: "var(--color-text-muted)" }}>
+                      All planets are in the alert section.
+                    </td>
+                  </tr>
+                )}
+              </tbody>
+            </table>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/app/planet-repairs/page.tsx
+++ b/app/planet-repairs/page.tsx
@@ -1,0 +1,9 @@
+import PlanetRepairsClient from "./PlanetRepairsClient";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
+export default function PlanetRepairsPage() {
+  return <PlanetRepairsClient />;
+}


### PR DESCRIPTION
## Summary

- New page at `/planet-repairs` showing estimated days since last repair for each of the user's planets, calculated from building condition data via the FIO API
- Planets approaching their user-defined target repair age (within 10 days) are surfaced in an alert section at the top; all others listed below in a sortable table
- Per-planet target ages are set via inline text inputs that commit on blur or Enter (to avoid triggering the alert section mid-typing) and are persisted in localStorage
- FIO credentials are shared with the bid-update page via the same localStorage keys — no re-entry needed
- Planet natural IDs are resolved to human-readable names via `/planet/allplanets`, fetched in parallel with building data

## Test plan

- [ ] Navigate to `/planet-repairs`
- [ ] Verify FIO credentials auto-populate if previously set on the bid-update page
- [ ] Click Fetch Data and confirm planets appear with days-since-repair values
- [ ] Set a target age for a planet and press Enter or click away — confirm it saves on page refresh
- [ ] Set a target age within 10 days of a planet's current days value — confirm it moves to the alert section
- [ ] Confirm planet names display instead of natural IDs
- [ ] Confirm the All Planets table is sortable by planet name and days since repair

🤖 Generated with [Claude Code](https://claude.com/claude-code)