### PR TITLE
Add resupply bidding opportunity scanner tool

### DIFF
--- a/app/resupply/ResupplyClient.tsx
+++ b/app/resupply/ResupplyClient.tsx
@@ -38,8 +38,16 @@ interface WarehouseEntry {
 interface RawData {
   warehouses: WarehouseEntry[];
   storage: StorageEntry[];
-  exchangeData: unknown[];
+  exchangeData: ExchangeTicker[];
   orders: unknown[];
+}
+
+interface ExchangeTicker {
+  MaterialTicker: string;
+  ExchangeCode: string;
+  Ask: number | null;
+  Bid: number | null;
+  [key: string]: unknown;
 }
 
 interface DeficitRow {
@@ -49,12 +57,59 @@ interface DeficitRow {
   deficit: number;
 }
 
+interface ExchangeBid {
+  exchange: string;
+  marketBid: number | null;
+  effectiveBid: number | null;
+  perUnitSavings: number | null;
+  netSavings: number | null;
+  returnPct: number | null;
+}
+
+interface ResupplyRow {
+  ticker: string;
+  deficit: number;
+  askAtSelected: number | null;
+  bids: Record<string, ExchangeBid>;
+  savingsAtSelected: number | null;
+  returnAtSelected: number | null;
+  bestSavings: number | null;
+  bestReturnPct: number | null;
+  bestExchange: string | null;
+}
+
 function formatNumber(value: number): string {
   return value.toLocaleString(undefined, {
     minimumFractionDigits: 0,
     maximumFractionDigits: 2,
   });
 }
+
+function formatCurrency(value: number): string {
+  return value.toLocaleString(undefined, {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  });
+}
+
+/** Increment at 3rd significant figure: 10.1→10.2, 1020→1030, 99→100, 0.5→0.501 */
+function incrementBid(n: number): number {
+  if (n <= 0) return 0.01;
+  const magnitude = Math.floor(Math.log10(n));
+  const increment = Math.pow(10, magnitude - 2);
+  const result = n + increment;
+  // Round to avoid floating point artifacts
+  const decimals = Math.max(0, 2 - magnitude);
+  return parseFloat(result.toFixed(decimals));
+}
+
+const EXCHANGE_CODES = ["AI1", "NC1", "CI1", "IC1"];
+const EXCHANGE_SHORT: Record<string, string> = {
+  AI1: "ANT",
+  NC1: "MOR",
+  CI1: "BEN",
+  IC1: "HRT",
+};
 
 export default function ResupplyClient() {
   const [rawData, setRawData] = useState<RawData | null>(null);
@@ -84,9 +139,27 @@ export default function ResupplyClient() {
     { updateUrl: false }
   );
   const [burnText, setBurnText] = useState("");
+  const [weeklyRate, setWeeklyRate] = usePersistedSettings<string>(
+    "prun:resupply:weeklyRate",
+    "3",
+    { updateUrl: false }
+  );
+  const [ignoreTickers, setIgnoreTickers] = usePersistedSettings<string>(
+    "prun:resupply:ignoreTickers",
+    "",
+    { updateUrl: false }
+  );
+  const [minSavings, setMinSavings] = usePersistedSettings<string>(
+    "prun:resupply:minSavings",
+    "0",
+    { updateUrl: false }
+  );
 
   const hasCredentials = fioUsername.trim() !== "" && fioApiKey.trim() !== "";
   const targetDaysNum = Math.max(1, parseInt(targetDays, 10) || 14);
+  const weeklyRateNum = Math.max(0, parseFloat(weeklyRate) || 3);
+  const minSavingsNum = Math.max(0, parseFloat(minSavings) || 0);
+  const ignoreTickersNormalized = ignoreTickers.split(/[,\s]+/).map(t => t.trim().toUpperCase()).filter(Boolean).sort().join(",");
 
   const fetchData = useCallback(async () => {
     if (!fioUsername.trim() || !fioApiKey.trim()) return;
@@ -190,6 +263,98 @@ export default function ResupplyClient() {
       warehouseWarning,
     };
   }, [burnText, rawData, selectedExchange, targetDaysNum]);
+
+  // --- Phase 3: Price comparison + savings calculation ---
+  const resupplyRows = useMemo(() => {
+    if (!rawData || deficitRows.length === 0) return [];
+
+    const ignoreSet = new Set(ignoreTickersNormalized ? ignoreTickersNormalized.split(",") : []);
+
+    // Step 4: Build exchange price lookups
+    const askMap = new Map<string, number>();
+    const bidMap = new Map<string, number>();
+    for (const entry of rawData.exchangeData) {
+      const key = `${entry.MaterialTicker}.${entry.ExchangeCode}`;
+      if (entry.Ask != null && entry.Ask > 0) askMap.set(key, entry.Ask);
+      if (entry.Bid != null && entry.Bid > 0) bidMap.set(key, entry.Bid);
+    }
+
+    // Step 5: Compute resupply rows
+    const returnThreshold = Math.pow(1 + weeklyRateNum / 100, targetDaysNum / 7) - 1;
+
+    const rows: ResupplyRow[] = [];
+    for (const dr of deficitRows) {
+      if (dr.deficit <= 0) continue;
+      if (ignoreSet.has(dr.ticker)) continue;
+
+      const askKey = `${dr.ticker}.${selectedExchange}`;
+      const askAtSelected = askMap.get(askKey) ?? null;
+
+      const bids: Record<string, ExchangeBid> = {};
+      let bestSavings: number | null = null;
+      let bestReturnPct: number | null = null;
+      let bestExchange: string | null = null;
+
+      for (const ex of EXCHANGE_CODES) {
+        const marketBid = bidMap.get(`${dr.ticker}.${ex}`) ?? null;
+        let effectiveBid: number | null = null;
+        let perUnitSavings: number | null = null;
+        let netSavings: number | null = null;
+        let returnPct: number | null = null;
+
+        if (marketBid != null) {
+          effectiveBid = incrementBid(marketBid);
+          if (askAtSelected != null) {
+            perUnitSavings = askAtSelected - effectiveBid;
+            returnPct = effectiveBid > 0 ? perUnitSavings / effectiveBid : null;
+            netSavings = perUnitSavings * dr.deficit;
+
+            if (netSavings != null && (bestSavings === null || netSavings > bestSavings)) {
+              bestSavings = netSavings;
+              bestReturnPct = returnPct;
+              bestExchange = ex;
+            }
+          }
+        }
+
+        bids[ex] = { exchange: ex, marketBid, effectiveBid, perUnitSavings, netSavings, returnPct };
+      }
+
+      const selectedBid = bids[selectedExchange];
+      const returnAtSelected = selectedBid?.returnPct ?? null;
+      const savingsAtSelected = selectedBid?.netSavings ?? null;
+
+      // Filter: include if return at selected OR best exchange >= threshold
+      const meetsThreshold =
+        (returnAtSelected !== null && returnAtSelected >= returnThreshold) ||
+        (bestReturnPct !== null && bestReturnPct >= returnThreshold);
+
+      if (!meetsThreshold) continue;
+
+      rows.push({
+        ticker: dr.ticker,
+        deficit: dr.deficit,
+        askAtSelected,
+        bids,
+        savingsAtSelected,
+        returnAtSelected,
+        bestSavings,
+        bestReturnPct,
+        bestExchange,
+      });
+    }
+
+    // Sort by net savings at selected exchange descending
+    rows.sort((a, b) => (b.savingsAtSelected ?? -Infinity) - (a.savingsAtSelected ?? -Infinity));
+
+    return rows;
+  }, [rawData, deficitRows, selectedExchange, targetDaysNum, weeklyRateNum, ignoreTickersNormalized]);
+
+  // Apply min savings filter
+  const filteredRows = useMemo(() => {
+    if (minSavingsNum <= 0) return resupplyRows;
+    return resupplyRows.filter(r => (r.savingsAtSelected ?? 0) >= minSavingsNum);
+  }, [resupplyRows, minSavingsNum]);
 
   return (
     <>
@@ -332,26 +497,71 @@ export default function ResupplyClient() {
               </div>
             )}
           </div>
-          <div style={{ display: "flex", flexDirection: "column", gap: "0.25rem" }}>
-            <label
-              style={{
-                fontFamily: "var(--font-mono)",
-                fontSize: "0.7rem",
-                color: "var(--color-text-muted)",
-                textTransform: "uppercase",
-                letterSpacing: "0.05em",
-              }}
-            >
-              Target Days
-            </label>
-            <input
-              type="number"
-              min="1"
-              value={targetDays}
-              onChange={(e) => setTargetDays(e.target.value)}
-              className="terminal-input"
-              style={{ width: "80px", textAlign: "center" }}
-            />
+          <div style={{ display: "flex", gap: "1rem", flexWrap: "wrap" }}>
+            <div style={{ display: "flex", flexDirection: "column", gap: "0.25rem" }}>
+              <label
+                style={{
+                  fontFamily: "var(--font-mono)",
+                  fontSize: "0.7rem",
+                  color: "var(--color-text-muted)",
+                  textTransform: "uppercase",
+                  letterSpacing: "0.05em",
+                }}
+              >
+                Target Days
+              </label>
+              <input
+                type="number"
+                min="1"
+                value={targetDays}
+                onChange={(e) => setTargetDays(e.target.value)}
+                className="terminal-input"
+                style={{ width: "80px", textAlign: "center" }}
+              />
+            </div>
+            <div style={{ display: "flex", flexDirection: "column", gap: "0.25rem" }}>
+              <label
+                style={{
+                  fontFamily: "var(--font-mono)",
+                  fontSize: "0.7rem",
+                  color: "var(--color-text-muted)",
+                  textTransform: "uppercase",
+                  letterSpacing: "0.05em",
+                }}
+              >
+                Weekly Return %
+              </label>
+              <input
+                type="number"
+                min="0"
+                step="0.5"
+                value={weeklyRate}
+                onChange={(e) => setWeeklyRate(e.target.value)}
+                className="terminal-input"
+                style={{ width: "80px", textAlign: "center" }}
+              />
+            </div>
+            <div style={{ display: "flex", flexDirection: "column", gap: "0.25rem" }}>
+              <label
+                style={{
+                  fontFamily: "var(--font-mono)",
+                  fontSize: "0.7rem",
+                  color: "var(--color-text-muted)",
+                  textTransform: "uppercase",
+                  letterSpacing: "0.05em",
+                }}
+              >
+                Ignore Tickers
+              </label>
+              <input
+                type="text"
+                placeholder="e.g. DW, RAT"
+                value={ignoreTickers}
+                onChange={(e) => setIgnoreTickers(e.target.value)}
+                className="terminal-input"
+                style={{ width: "160px" }}
+              />
+            </div>
           </div>
         </div>
       </div>
@@ -443,11 +653,21 @@ export default function ResupplyClient() {
         </div>
       )}
 
-      {/* Deficit Table */}
-      {deficitRows.length > 0 && (
+      {/* Deficit Table — shown when burn data parsed but no API data yet */}
+      {deficitRows.length > 0 && !rawData && (
         <div className="terminal-box" style={{ marginBottom: "2rem" }}>
           <div className="terminal-header" style={{ marginBottom: "1rem" }}>
-            Supply Deficits — {EXCHANGE_LOCATION[selectedExchange]} — {targetDaysNum} day target ({deficitRows.filter(r => r.deficit > 0).length} need resupply)
+            Supply Deficits — {targetDaysNum} day target ({deficitRows.filter(r => r.deficit > 0).length} need resupply)
+          </div>
+          <div
+            style={{
+              fontFamily: "var(--font-mono)",
+              fontSize: "0.8rem",
+              color: "var(--color-text-muted)",
+              marginBottom: "1rem",
+            }}
+          >
+            Fetch data to see price comparisons and savings across exchanges.
           </div>
           <div style={{ overflowX: "auto" }}>
             <table
@@ -522,6 +742,191 @@ export default function ResupplyClient() {
               </tbody>
             </table>
           </div>
+        </div>
+      )}
+
+      {/* Resupply Results Table */}
+      {rawData && parsedCount > 0 && (
+        <div className="terminal-box" style={{ marginBottom: "2rem" }}>
+          <div
+            style={{
+              display: "flex",
+              justifyContent: "space-between",
+              alignItems: "center",
+              flexWrap: "wrap",
+              gap: "1rem",
+              marginBottom: "1rem",
+            }}
+          >
+            <div className="terminal-header" style={{ margin: 0 }}>
+              Resupply Opportunities — {EXCHANGE_LOCATION[selectedExchange]} ({filteredRows.length} of {resupplyRows.length})
+            </div>
+            <div style={{ display: "flex", alignItems: "center", gap: "0.5rem" }}>
+              <label
+                style={{
+                  fontFamily: "var(--font-mono)",
+                  fontSize: "0.7rem",
+                  color: "var(--color-text-muted)",
+                  textTransform: "uppercase",
+                  letterSpacing: "0.05em",
+                }}
+              >
+                Min Savings
+              </label>
+              <input
+                type="number"
+                min="0"
+                value={minSavings}
+                onChange={(e) => setMinSavings(e.target.value)}
+                className="terminal-input"
+                style={{ width: "80px", textAlign: "center" }}
+              />
+            </div>
+          </div>
+          {filteredRows.length === 0 ? (
+            <div
+              style={{
+                fontFamily: "var(--font-mono)",
+                fontSize: "0.8rem",
+                color: "var(--color-text-muted)",
+                textAlign: "center",
+                padding: "2rem 1rem",
+              }}
+            >
+              No tickers meet the {weeklyRateNum}% weekly return threshold
+              {minSavingsNum > 0 ? ` and ${formatCurrency(minSavingsNum)} min savings filter` : ""}.
+            </div>
+          ) : (
+            <div style={{ overflowX: "auto" }}>
+              <table
+                style={{
+                  width: "100%",
+                  borderCollapse: "collapse",
+                  fontFamily: "var(--font-mono)",
+                  fontSize: "0.8rem",
+                }}
+              >
+                <thead>
+                  <tr>
+                    {[
+                      { label: "Ticker", align: "left" },
+                      { label: "Deficit", align: "right" },
+                      { label: `Ask (${EXCHANGE_SHORT[selectedExchange]})`, align: "right" },
+                      ...EXCHANGE_CODES.map(ex => ({ label: `Bid (${EXCHANGE_SHORT[ex]})`, align: "right" as const })),
+                      { label: "Savings @ Selected", align: "right" },
+                      { label: "Best Savings", align: "right" },
+                    ].map((col) => (
+                      <th
+                        key={col.label}
+                        style={{
+                          padding: "0.5rem 0.6rem",
+                          borderBottom: "1px solid var(--color-border-primary)",
+                          fontSize: "0.7rem",
+                          textTransform: "uppercase",
+                          letterSpacing: "0.05em",
+                          color: "var(--color-text-secondary)",
+                          textAlign: col.align as "left" | "right",
+                          whiteSpace: "nowrap",
+                        }}
+                      >
+                        {col.label}
+                      </th>
+                    ))}
+                  </tr>
+                </thead>
+                <tbody>
+                  {filteredRows.map((row) => (
+                    <tr
+                      key={row.ticker}
+                      style={{
+                        borderBottom: "1px solid var(--color-border-secondary, rgba(255,255,255,0.05))",
+                      }}
+                    >
+                      <td
+                        style={{
+                          padding: "0.5rem 0.6rem",
+                          color: "var(--color-accent-primary)",
+                          fontWeight: "bold",
+                        }}
+                      >
+                        {row.ticker}
+                      </td>
+                      <td style={{ padding: "0.5rem 0.6rem", textAlign: "right" }}>
+                        {formatNumber(row.deficit)}
+                      </td>
+                      <td style={{ padding: "0.5rem 0.6rem", textAlign: "right" }}>
+                        {row.askAtSelected != null ? formatCurrency(row.askAtSelected) : "—"}
+                      </td>
+                      {EXCHANGE_CODES.map((ex) => {
+                        const bid = row.bids[ex];
+                        const isSelected = ex === selectedExchange;
+                        return (
+                          <td
+                            key={ex}
+                            style={{
+                              padding: "0.5rem 0.6rem",
+                              textAlign: "right",
+                              fontWeight: isSelected ? "bold" : "normal",
+                              color: isSelected
+                                ? "var(--color-accent-primary)"
+                                : "var(--color-text-secondary)",
+                            }}
+                          >
+                            {bid?.marketBid != null ? formatCurrency(bid.marketBid) : "—"}
+                          </td>
+                        );
+                      })}
+                      <td
+                        style={{
+                          padding: "0.5rem 0.6rem",
+                          textAlign: "right",
+                          color: (row.savingsAtSelected ?? 0) > 0
+                            ? "var(--color-accent-primary)"
+                            : "var(--color-text-muted)",
+                        }}
+                      >
+                        {row.savingsAtSelected != null ? (
+                          <>
+                            {formatCurrency(row.savingsAtSelected)}
+                            {row.returnAtSelected != null && (
+                              <span style={{ fontSize: "0.7rem", color: "var(--color-text-muted)", marginLeft: "0.3rem" }}>
+                                ({(row.returnAtSelected * 100).toFixed(1)}%)
+                              </span>
+                            )}
+                          </>
+                        ) : "—"}
+                      </td>
+                      <td
+                        style={{
+                          padding: "0.5rem 0.6rem",
+                          textAlign: "right",
+                          color: (row.bestSavings ?? 0) > 0
+                            ? "var(--color-accent-primary)"
+                            : "var(--color-text-muted)",
+                        }}
+                      >
+                        {row.bestSavings != null ? (
+                          <>
+                            {formatCurrency(row.bestSavings)}
+                            {row.bestReturnPct != null && (
+                              <span style={{ fontSize: "0.7rem", color: "var(--color-text-muted)", marginLeft: "0.3rem" }}>
+                                ({(row.bestReturnPct * 100).toFixed(1)}%)
+                              </span>
+                            )}
+                            {row.bestExchange && row.bestExchange !== selectedExchange && (
+                              <span style={{ fontSize: "0.65rem", color: "var(--color-text-muted)", marginLeft: "0.3rem" }}>
+                                {EXCHANGE_SHORT[row.bestExchange]}
+                              </span>
+                            )}
+                          </>
+                        ) : "—"}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
         </div>
       )}
 

--- a/app/resupply/ResupplyClient.tsx
+++ b/app/resupply/ResupplyClient.tsx
@@ -104,9 +104,17 @@ function formatNumber(value: number): string {
 }
 
 function formatCurrency(value: number): string {
-  return value.toLocaleString(undefined, {
-    minimumFractionDigits: 2,
-    maximumFractionDigits: 2,
+  // Whole numbers shown without decimals; otherwise show one decimal place
+  const rounded = Math.round(value * 10) / 10;
+  if (rounded === Math.trunc(rounded)) {
+    return rounded.toLocaleString(undefined, {
+      minimumFractionDigits: 0,
+      maximumFractionDigits: 0,
+    });
+  }
+  return rounded.toLocaleString(undefined, {
+    minimumFractionDigits: 1,
+    maximumFractionDigits: 1,
   });
 }
 
@@ -406,8 +414,8 @@ export default function ResupplyClient() {
       });
     }
 
-    // Sort by net savings at selected exchange descending
-    rows.sort((a, b) => (b.savingsAtSelected ?? -Infinity) - (a.savingsAtSelected ?? -Infinity));
+    // Sort by best net savings descending
+    rows.sort((a, b) => (b.bestSavings ?? -Infinity) - (a.bestSavings ?? -Infinity));
 
     return { resupplyRows: rows, staleBids };
   }, [rawData, deficitRows, selectedExchange, targetDaysNum, weeklyRateNum, ignoreTickersNormalized]);
@@ -415,7 +423,7 @@ export default function ResupplyClient() {
   // Apply min savings filter
   const filteredRows = useMemo(() => {
     if (minSavingsNum <= 0) return resupplyRows;
-    return resupplyRows.filter(r => (r.savingsAtSelected ?? 0) >= minSavingsNum);
+    return resupplyRows.filter(r => (r.bestSavings ?? 0) >= minSavingsNum);
   }, [resupplyRows, minSavingsNum]);
 
   return (
@@ -1082,7 +1090,7 @@ export default function ResupplyClient() {
                                 ({(row.bestReturnPct * 100).toFixed(1)}%)
                               </span>
                             )}
-                            {row.bestExchange && row.bestExchange !== selectedExchange && (
+                            {row.bestExchange && (
                               <span style={{ fontSize: "0.65rem", color: "var(--color-text-muted)", marginLeft: "0.3rem" }}>
                                 {EXCHANGE_SHORT[row.bestExchange]}
                               </span>

--- a/app/resupply/ResupplyClient.tsx
+++ b/app/resupply/ResupplyClient.tsx
@@ -39,7 +39,7 @@ interface RawData {
   warehouses: WarehouseEntry[];
   storage: StorageEntry[];
   exchangeData: ExchangeTicker[];
-  orders: unknown[];
+  orders: CxosOrder[];
 }
 
 interface ExchangeTicker {
@@ -47,6 +47,16 @@ interface ExchangeTicker {
   ExchangeCode: string;
   Ask: number | null;
   Bid: number | null;
+  [key: string]: unknown;
+}
+
+interface CxosOrder {
+  MaterialTicker: string;
+  ExchangeCode: string;
+  OrderType: string;
+  Status: string;
+  Limit: number;
+  Amount: number;
   [key: string]: unknown;
 }
 
@@ -76,6 +86,14 @@ interface ResupplyRow {
   bestSavings: number | null;
   bestReturnPct: number | null;
   bestExchange: string | null;
+}
+
+interface StaleBid {
+  ticker: string;
+  exchange: string;
+  myLimit: number;
+  marketBid: number;
+  amount: number;
 }
 
 function formatNumber(value: number): string {
@@ -264,9 +282,10 @@ export default function ResupplyClient() {
     };
   }, [burnText, rawData, selectedExchange, targetDaysNum]);
 
-  // --- Phase 3: Price comparison + savings calculation ---
-  const resupplyRows = useMemo(() => {
-    if (!rawData || deficitRows.length === 0) return [];
+  // --- Phase 3 + 4: Price comparison, order integration, savings calculation ---
+  const { resupplyRows, staleBids } = useMemo(() => {
+    const empty = { resupplyRows: [] as ResupplyRow[], staleBids: [] as StaleBid[] };
+    if (!rawData || deficitRows.length === 0) return empty;
 
     const ignoreSet = new Set(ignoreTickersNormalized ? ignoreTickersNormalized.split(",") : []);
 
@@ -279,13 +298,53 @@ export default function ResupplyClient() {
       if (entry.Bid != null && entry.Bid > 0) bidMap.set(key, entry.Bid);
     }
 
-    // Step 5: Compute resupply rows
+    // Step 4b (Phase 4): Process user orders — classify top bids vs stale bids
+    const staleBids: StaleBid[] = [];
+    // topBidMap: "TICKER.EXCHANGE" → limit price (for effective bid calculation)
+    const topBidMap = new Map<string, number>();
+    // topBidDeductions: ticker → total amount covered by existing top bids
+    const topBidDeductions = new Map<string, number>();
+
+    for (const order of rawData.orders) {
+      const orderType = (order.OrderType || "").toString().toUpperCase();
+      const status = (order.Status || "").toString().toUpperCase();
+      if (orderType !== "BUYING") continue;
+      if (status !== "PLACED" && status !== "PARTIALLY_FILLED") continue;
+
+      const key = `${order.MaterialTicker}.${order.ExchangeCode}`;
+      const marketBid = bidMap.get(key);
+
+      if (marketBid != null && order.Limit === marketBid) {
+        // User has top bid at this exchange
+        topBidMap.set(key, order.Limit);
+        topBidDeductions.set(
+          order.MaterialTicker,
+          (topBidDeductions.get(order.MaterialTicker) || 0) + order.Amount
+        );
+      } else if (marketBid != null) {
+        // Stale bid — limit doesn't match market
+        staleBids.push({
+          ticker: order.MaterialTicker,
+          exchange: order.ExchangeCode,
+          myLimit: order.Limit,
+          marketBid,
+          amount: order.Amount,
+        });
+      }
+    }
+
+    // Step 5: Compute resupply rows (with order-aware deficits and effective bids)
     const returnThreshold = Math.pow(1 + weeklyRateNum / 100, targetDaysNum / 7) - 1;
 
     const rows: ResupplyRow[] = [];
     for (const dr of deficitRows) {
       if (dr.deficit <= 0) continue;
       if (ignoreSet.has(dr.ticker)) continue;
+
+      // Deduct top-bid amounts from deficit
+      const deduction = topBidDeductions.get(dr.ticker) || 0;
+      const adjustedDeficit = dr.deficit - deduction;
+      if (adjustedDeficit <= 0) continue;
 
       const askKey = `${dr.ticker}.${selectedExchange}`;
       const askAtSelected = askMap.get(askKey) ?? null;
@@ -303,11 +362,14 @@ export default function ResupplyClient() {
         let returnPct: number | null = null;
 
         if (marketBid != null) {
-          effectiveBid = incrementBid(marketBid);
+          // If user has top bid at this exchange, use their limit price
+          const userTopBid = topBidMap.get(`${dr.ticker}.${ex}`);
+          effectiveBid = userTopBid != null ? userTopBid : incrementBid(marketBid);
+
           if (askAtSelected != null) {
             perUnitSavings = askAtSelected - effectiveBid;
             returnPct = effectiveBid > 0 ? perUnitSavings / effectiveBid : null;
-            netSavings = perUnitSavings * dr.deficit;
+            netSavings = perUnitSavings * adjustedDeficit;
 
             if (netSavings != null && (bestSavings === null || netSavings > bestSavings)) {
               bestSavings = netSavings;
@@ -333,7 +395,7 @@ export default function ResupplyClient() {
 
       rows.push({
         ticker: dr.ticker,
-        deficit: dr.deficit,
+        deficit: adjustedDeficit,
         askAtSelected,
         bids,
         savingsAtSelected,
@@ -347,7 +409,7 @@ export default function ResupplyClient() {
     // Sort by net savings at selected exchange descending
     rows.sort((a, b) => (b.savingsAtSelected ?? -Infinity) - (a.savingsAtSelected ?? -Infinity));
 
-    return rows;
+    return { resupplyRows: rows, staleBids };
   }, [rawData, deficitRows, selectedExchange, targetDaysNum, weeklyRateNum, ignoreTickersNormalized]);
 
   // Apply min savings filter
@@ -653,6 +715,113 @@ export default function ResupplyClient() {
         </div>
       )}
 
+      {/* Summary Stats */}
+      {rawData && parsedCount > 0 && (
+        <div
+          className="terminal-box"
+          style={{
+            marginBottom: "2rem",
+            display: "flex",
+            gap: "2rem",
+            flexWrap: "wrap",
+          }}
+        >
+          <div>
+            <div
+              style={{
+                fontFamily: "var(--font-mono)",
+                fontSize: "0.7rem",
+                color: "var(--color-text-muted)",
+                textTransform: "uppercase",
+                marginBottom: "0.25rem",
+              }}
+            >
+              Deficit Tickers
+            </div>
+            <div
+              style={{
+                fontFamily: "var(--font-mono)",
+                fontSize: "1.25rem",
+                color: "var(--color-text-primary)",
+              }}
+            >
+              {deficitRows.filter(r => r.deficit > 0).length}
+            </div>
+          </div>
+          <div>
+            <div
+              style={{
+                fontFamily: "var(--font-mono)",
+                fontSize: "0.7rem",
+                color: "var(--color-text-muted)",
+                textTransform: "uppercase",
+                marginBottom: "0.25rem",
+              }}
+            >
+              Bid Opportunities
+            </div>
+            <div
+              style={{
+                fontFamily: "var(--font-mono)",
+                fontSize: "1.25rem",
+                color: "var(--color-text-primary)",
+              }}
+            >
+              {resupplyRows.length}
+            </div>
+          </div>
+          <div>
+            <div
+              style={{
+                fontFamily: "var(--font-mono)",
+                fontSize: "0.7rem",
+                color: "var(--color-text-muted)",
+                textTransform: "uppercase",
+                marginBottom: "0.25rem",
+              }}
+            >
+              Total Potential Savings
+            </div>
+            <div
+              style={{
+                fontFamily: "var(--font-mono)",
+                fontSize: "1.25rem",
+                color: "var(--color-accent-primary)",
+              }}
+            >
+              {formatCurrency(
+                resupplyRows.reduce((sum, r) => sum + (r.savingsAtSelected ?? 0), 0)
+              )}
+            </div>
+          </div>
+          <div>
+            <div
+              style={{
+                fontFamily: "var(--font-mono)",
+                fontSize: "0.7rem",
+                color: "var(--color-text-muted)",
+                textTransform: "uppercase",
+                marginBottom: "0.25rem",
+              }}
+            >
+              Stale Bids
+            </div>
+            <div
+              style={{
+                fontFamily: "var(--font-mono)",
+                fontSize: "1.25rem",
+                color:
+                  staleBids.length > 0
+                    ? "var(--color-error, #ff4444)"
+                    : "var(--color-success, #44ff44)",
+              }}
+            >
+              {staleBids.length}
+            </div>
+          </div>
+        </div>
+      )}
+
       {/* Deficit Table — shown when burn data parsed but no API data yet */}
       {deficitRows.length > 0 && !rawData && (
         <div className="terminal-box" style={{ marginBottom: "2rem" }}>
@@ -927,6 +1096,112 @@ export default function ResupplyClient() {
               </table>
             </div>
           )}
+        </div>
+      )}
+
+      {/* Stale Bids Warning */}
+      {staleBids.length > 0 && (
+        <div
+          className="terminal-box"
+          style={{
+            marginBottom: "2rem",
+            borderColor: "var(--color-error, #ff4444)",
+          }}
+        >
+          <div
+            className="terminal-header"
+            style={{
+              marginBottom: "1rem",
+              color: "var(--color-error, #ff4444)",
+            }}
+          >
+            Stale Bids — {staleBids.length} orders need attention
+          </div>
+          <div
+            style={{
+              fontFamily: "var(--font-mono)",
+              fontSize: "0.75rem",
+              color: "var(--color-text-muted)",
+              marginBottom: "1rem",
+            }}
+          >
+            These buy orders no longer match the market bid. Consider updating or removing them in-game.
+          </div>
+          <div style={{ overflowX: "auto" }}>
+            <table
+              style={{
+                width: "100%",
+                borderCollapse: "collapse",
+                fontFamily: "var(--font-mono)",
+                fontSize: "0.8rem",
+              }}
+            >
+              <thead>
+                <tr>
+                  {[
+                    { label: "Ticker", align: "left" },
+                    { label: "Exchange", align: "left" },
+                    { label: "My Limit", align: "right" },
+                    { label: "Market Bid", align: "right" },
+                    { label: "Amount", align: "right" },
+                  ].map((col) => (
+                    <th
+                      key={col.label}
+                      style={{
+                        padding: "0.5rem 0.75rem",
+                        borderBottom: "1px solid var(--color-border-primary)",
+                        fontSize: "0.7rem",
+                        textTransform: "uppercase",
+                        letterSpacing: "0.05em",
+                        color: "var(--color-text-secondary)",
+                        textAlign: col.align as "left" | "right",
+                      }}
+                    >
+                      {col.label}
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody>
+                {staleBids.map((sb, i) => (
+                  <tr
+                    key={`${sb.ticker}-${sb.exchange}-${i}`}
+                    style={{
+                      borderBottom: "1px solid var(--color-border-secondary, rgba(255,255,255,0.05))",
+                    }}
+                  >
+                    <td
+                      style={{
+                        padding: "0.5rem 0.75rem",
+                        color: "var(--color-accent-primary)",
+                        fontWeight: "bold",
+                      }}
+                    >
+                      {sb.ticker}
+                    </td>
+                    <td style={{ padding: "0.5rem 0.75rem" }}>
+                      {EXCHANGE_SHORT[sb.exchange] || sb.exchange}
+                    </td>
+                    <td style={{ padding: "0.5rem 0.75rem", textAlign: "right" }}>
+                      {formatCurrency(sb.myLimit)}
+                    </td>
+                    <td
+                      style={{
+                        padding: "0.5rem 0.75rem",
+                        textAlign: "right",
+                        color: "var(--color-accent-primary)",
+                      }}
+                    >
+                      {formatCurrency(sb.marketBid)}
+                    </td>
+                    <td style={{ padding: "0.5rem 0.75rem", textAlign: "right" }}>
+                      {formatNumber(sb.amount)}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
         </div>
       )}
 

--- a/app/resupply/ResupplyClient.tsx
+++ b/app/resupply/ResupplyClient.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useMemo } from "react";
 import { usePersistedSettings } from "@/hooks/usePersistedSettings";
 
 const EXCHANGE_OPTIONS = [
@@ -10,8 +10,51 @@ const EXCHANGE_OPTIONS = [
   { code: "IC1", label: "Hortus Station (IC1)" },
 ];
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-type RawData = Record<string, any>;
+const EXCHANGE_LOCATION: Record<string, string> = {
+  AI1: "Antares Station",
+  NC1: "Moria Station",
+  CI1: "Benten Station",
+  IC1: "Hortus Station",
+};
+
+interface StorageItem {
+  MaterialTicker: string;
+  MaterialAmount: number;
+  [key: string]: unknown;
+}
+
+interface StorageEntry {
+  StorageId: string;
+  StorageItems: StorageItem[];
+  [key: string]: unknown;
+}
+
+interface WarehouseEntry {
+  LocationName: string;
+  StoreId: string;
+  [key: string]: unknown;
+}
+
+interface RawData {
+  warehouses: WarehouseEntry[];
+  storage: StorageEntry[];
+  exchangeData: unknown[];
+  orders: unknown[];
+}
+
+interface DeficitRow {
+  ticker: string;
+  demand: number;
+  onHand: number;
+  deficit: number;
+}
+
+function formatNumber(value: number): string {
+  return value.toLocaleString(undefined, {
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 2,
+  });
+}
 
 export default function ResupplyClient() {
   const [rawData, setRawData] = useState<RawData | null>(null);
@@ -35,8 +78,15 @@ export default function ResupplyClient() {
     "AI1",
     { updateUrl: false }
   );
+  const [targetDays, setTargetDays] = usePersistedSettings<string>(
+    "prun:resupply:targetDays",
+    "14",
+    { updateUrl: false }
+  );
+  const [burnText, setBurnText] = useState("");
 
   const hasCredentials = fioUsername.trim() !== "" && fioApiKey.trim() !== "";
+  const targetDaysNum = Math.max(1, parseInt(targetDays, 10) || 14);
 
   const fetchData = useCallback(async () => {
     if (!fioUsername.trim() || !fioApiKey.trim()) return;
@@ -66,6 +116,80 @@ export default function ResupplyClient() {
   useEffect(() => {
     if (hasCredentials) fetchData();
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // --- Phase 2: Burn parsing + warehouse matching + deficit calculation ---
+  const { deficitRows, parsedCount, warehouseWarning } = useMemo(() => {
+    const empty = { deficitRows: [] as DeficitRow[], parsedCount: 0, warehouseWarning: "" };
+    if (!burnText.trim()) return empty;
+
+    // Step 1: Parse burn table
+    const lines = burnText.trim().split("\n");
+    const consumptionByTicker = new Map<string, number>();
+    for (const line of lines) {
+      const cols = line.split("\t");
+      if (cols.length < 5) continue;
+      const [planet, ticker, , burnPerDayStr] = cols;
+      if (planet?.trim() !== "Overall") continue;
+      const burnPerDay = parseFloat(burnPerDayStr);
+      if (isNaN(burnPerDay) || burnPerDay >= 0) continue; // consumption only
+      const demand = Math.abs(burnPerDay) * targetDaysNum;
+      consumptionByTicker.set(
+        ticker.trim(),
+        (consumptionByTicker.get(ticker.trim()) || 0) + demand
+      );
+    }
+
+    if (consumptionByTicker.size === 0) return empty;
+
+    // Step 2: Get on-hand supply at selected exchange
+    let warehouseWarning = "";
+    const onHandMap = new Map<string, number>();
+
+    if (rawData) {
+      const locationName = EXCHANGE_LOCATION[selectedExchange];
+      const warehouse = rawData.warehouses?.find(
+        (w: WarehouseEntry) => w.LocationName === locationName
+      );
+
+      if (!warehouse) {
+        warehouseWarning = `No warehouse found at ${locationName}. On-hand quantities will be 0.`;
+      } else {
+        const storageEntry = rawData.storage?.find(
+          (s: StorageEntry) => s.StorageId === warehouse.StoreId
+        );
+        if (storageEntry?.StorageItems) {
+          for (const item of storageEntry.StorageItems) {
+            onHandMap.set(
+              item.MaterialTicker,
+              (onHandMap.get(item.MaterialTicker) || 0) + item.MaterialAmount
+            );
+          }
+        }
+      }
+    }
+
+    // Step 3: Compute deficits
+    const deficitRows: DeficitRow[] = [];
+    for (const [ticker, demand] of consumptionByTicker) {
+      const onHand = onHandMap.get(ticker) || 0;
+      const deficit = demand - onHand;
+      deficitRows.push({ ticker, demand, onHand, deficit });
+    }
+
+    // Sort: items with deficit > 0 first (by deficit desc), then stocked items
+    deficitRows.sort((a, b) => {
+      if (a.deficit > 0 && b.deficit <= 0) return -1;
+      if (a.deficit <= 0 && b.deficit > 0) return 1;
+      if (a.deficit > 0 && b.deficit > 0) return b.deficit - a.deficit;
+      return a.ticker.localeCompare(b.ticker);
+    });
+
+    return {
+      deficitRows,
+      parsedCount: consumptionByTicker.size,
+      warehouseWarning,
+    };
+  }, [burnText, rawData, selectedExchange, targetDaysNum]);
 
   return (
     <>
@@ -164,6 +288,74 @@ export default function ResupplyClient() {
         </select>
       </div>
 
+      {/* Burn Table + Target Days */}
+      <div className="terminal-box" style={{ marginBottom: "2rem" }}>
+        <div className="terminal-header" style={{ marginBottom: "1rem" }}>
+          Burn Data
+        </div>
+        <div
+          style={{
+            display: "flex",
+            gap: "1rem",
+            flexWrap: "wrap",
+            alignItems: "flex-start",
+          }}
+        >
+          <div style={{ flex: "1 1 400px" }}>
+            <textarea
+              placeholder="Paste burn table from game (select all rows in BUI BRA burn section, copy with Ctrl+C)"
+              value={burnText}
+              onChange={(e) => setBurnText(e.target.value)}
+              className="terminal-input"
+              rows={4}
+              style={{
+                width: "100%",
+                resize: "vertical",
+                fontFamily: "var(--font-mono)",
+                fontSize: "0.75rem",
+              }}
+            />
+            {burnText.trim() && (
+              <div
+                style={{
+                  marginTop: "0.5rem",
+                  fontFamily: "var(--font-mono)",
+                  fontSize: "0.75rem",
+                  color: parsedCount > 0
+                    ? "var(--color-text-secondary)"
+                    : "var(--color-error, #ff4444)",
+                }}
+              >
+                {parsedCount > 0
+                  ? `Parsed ${parsedCount} consumption items from Overall`
+                  : "No consumption items found. Ensure burn table has Overall rows with negative Burn/day."}
+              </div>
+            )}
+          </div>
+          <div style={{ display: "flex", flexDirection: "column", gap: "0.25rem" }}>
+            <label
+              style={{
+                fontFamily: "var(--font-mono)",
+                fontSize: "0.7rem",
+                color: "var(--color-text-muted)",
+                textTransform: "uppercase",
+                letterSpacing: "0.05em",
+              }}
+            >
+              Target Days
+            </label>
+            <input
+              type="number"
+              min="1"
+              value={targetDays}
+              onChange={(e) => setTargetDays(e.target.value)}
+              className="terminal-input"
+              style={{ width: "80px", textAlign: "center" }}
+            />
+          </div>
+        </div>
+      </div>
+
       {/* Controls */}
       <div
         style={{
@@ -230,42 +422,105 @@ export default function ResupplyClient() {
         </div>
       )}
 
-      {/* Data Summary */}
-      {rawData && !showDebug && (
-        <div className="terminal-box" style={{ marginBottom: "2rem" }}>
-          <div className="terminal-header" style={{ marginBottom: "1rem" }}>
-            Data Loaded
-          </div>
+      {/* Warehouse Warning */}
+      {warehouseWarning && rawData && (
+        <div
+          className="terminal-box"
+          style={{
+            marginBottom: "2rem",
+            borderColor: "var(--color-accent-primary)",
+          }}
+        >
           <div
             style={{
+              color: "var(--color-accent-primary)",
               fontFamily: "var(--font-mono)",
               fontSize: "0.8rem",
-              color: "var(--color-text-secondary)",
-              lineHeight: "1.8",
             }}
           >
-            <div>
-              Warehouses: {Array.isArray(rawData.warehouses) ? rawData.warehouses.length : 0} entries
-            </div>
-            <div>
-              Storage: {Array.isArray(rawData.storage) ? rawData.storage.length : 0} entries
-            </div>
-            <div>
-              Exchange tickers: {Array.isArray(rawData.exchangeData) ? rawData.exchangeData.length : 0} entries
-            </div>
-            <div>
-              Open orders: {Array.isArray(rawData.orders) ? rawData.orders.length : 0} entries
-            </div>
-            <div
+            [WARN] {warehouseWarning}
+          </div>
+        </div>
+      )}
+
+      {/* Deficit Table */}
+      {deficitRows.length > 0 && (
+        <div className="terminal-box" style={{ marginBottom: "2rem" }}>
+          <div className="terminal-header" style={{ marginBottom: "1rem" }}>
+            Supply Deficits — {EXCHANGE_LOCATION[selectedExchange]} — {targetDaysNum} day target ({deficitRows.filter(r => r.deficit > 0).length} need resupply)
+          </div>
+          <div style={{ overflowX: "auto" }}>
+            <table
               style={{
-                marginTop: "1rem",
-                color: "var(--color-text-muted)",
-                fontSize: "0.75rem",
+                width: "100%",
+                borderCollapse: "collapse",
+                fontFamily: "var(--font-mono)",
+                fontSize: "0.875rem",
               }}
             >
-              Phase 1 complete. Burn table parsing and deficit calculation coming
-              in Phase 2.
-            </div>
+              <thead>
+                <tr>
+                  {["Ticker", "Demand", "On-Hand", "Deficit"].map((label, i) => (
+                    <th
+                      key={label}
+                      style={{
+                        padding: "0.5rem 0.75rem",
+                        borderBottom: "1px solid var(--color-border-primary)",
+                        fontSize: "0.75rem",
+                        textTransform: "uppercase",
+                        letterSpacing: "0.05em",
+                        color: "var(--color-text-secondary)",
+                        textAlign: i === 0 ? "left" : "right",
+                      }}
+                    >
+                      {label}
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody>
+                {deficitRows.map((row) => {
+                  const isStocked = row.deficit <= 0;
+                  return (
+                    <tr
+                      key={row.ticker}
+                      style={{
+                        borderBottom: "1px solid var(--color-border-secondary, rgba(255,255,255,0.05))",
+                        opacity: isStocked ? 0.4 : 1,
+                      }}
+                    >
+                      <td
+                        style={{
+                          padding: "0.5rem 0.75rem",
+                          color: "var(--color-accent-primary)",
+                          fontWeight: "bold",
+                        }}
+                      >
+                        {row.ticker}
+                      </td>
+                      <td style={{ padding: "0.5rem 0.75rem", textAlign: "right" }}>
+                        {formatNumber(row.demand)}
+                      </td>
+                      <td style={{ padding: "0.5rem 0.75rem", textAlign: "right" }}>
+                        {formatNumber(row.onHand)}
+                      </td>
+                      <td
+                        style={{
+                          padding: "0.5rem 0.75rem",
+                          textAlign: "right",
+                          color: isStocked
+                            ? "var(--color-text-muted)"
+                            : "var(--color-accent-primary)",
+                          fontWeight: isStocked ? "normal" : "bold",
+                        }}
+                      >
+                        {isStocked ? "Stocked" : formatNumber(row.deficit)}
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
           </div>
         </div>
       )}

--- a/app/resupply/ResupplyClient.tsx
+++ b/app/resupply/ResupplyClient.tsx
@@ -141,7 +141,6 @@ export default function ResupplyClient() {
   const [rawData, setRawData] = useState<RawData | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [showDebug, setShowDebug] = useState(false);
   const [lastRefresh, setLastRefresh] = useState<Date | null>(null);
 
   const [fioUsername, setFioUsername] = usePersistedSettings<string>(
@@ -186,6 +185,7 @@ export default function ResupplyClient() {
   const weeklyRateNum = Math.max(0, parseFloat(weeklyRate) || 3);
   const minSavingsNum = Math.max(0, parseFloat(minSavings) || 0);
   const ignoreTickersNormalized = ignoreTickers.split(/[,\s]+/).map(t => t.trim().toUpperCase()).filter(Boolean).sort().join(",");
+  const returnFloorPct = (Math.pow(1 + weeklyRateNum / 100, targetDaysNum / 7) - 1) * 100;
 
   const fetchData = useCallback(async () => {
     if (!fioUsername.trim() || !fioApiKey.trim()) return;
@@ -462,35 +462,157 @@ export default function ResupplyClient() {
         </p>
       </div>
 
-      {/* FIO Credentials */}
+      {/* Settings */}
       <div className="terminal-box" style={{ marginBottom: "2rem" }}>
         <div className="terminal-header" style={{ marginBottom: "1rem" }}>
-          FIO Credentials
+          Settings
         </div>
         <div
           style={{
             display: "flex",
             gap: "1rem",
             flexWrap: "wrap",
-            alignItems: "center",
+            alignItems: "flex-start",
           }}
         >
-          <input
-            type="text"
-            placeholder="FIO username"
-            value={fioUsername}
-            onChange={(e) => setFioUsername(e.target.value)}
-            className="terminal-input"
-            style={{ flex: 1, minWidth: "150px", maxWidth: "250px" }}
-          />
-          <input
-            type="password"
-            placeholder="FIO API key"
-            value={fioApiKey}
-            onChange={(e) => setFioApiKey(e.target.value)}
-            className="terminal-input"
-            style={{ flex: 2, minWidth: "250px", maxWidth: "450px" }}
-          />
+          <div style={{ display: "flex", flexDirection: "column", gap: "0.25rem", flex: "1 1 200px", minWidth: "180px" }}>
+            <label
+              style={{
+                fontFamily: "var(--font-mono)",
+                fontSize: "0.7rem",
+                color: "var(--color-text-muted)",
+                textTransform: "uppercase",
+                letterSpacing: "0.05em",
+              }}
+            >
+              FIO Username <span style={{ textTransform: "none", opacity: 0.7 }}>(local storage only)</span>
+            </label>
+            <input
+              type="text"
+              value={fioUsername}
+              onChange={(e) => setFioUsername(e.target.value)}
+              className="terminal-input"
+              style={{ width: "100%" }}
+            />
+          </div>
+          <div style={{ display: "flex", flexDirection: "column", gap: "0.25rem", flex: "2 1 280px", minWidth: "240px" }}>
+            <label
+              style={{
+                fontFamily: "var(--font-mono)",
+                fontSize: "0.7rem",
+                color: "var(--color-text-muted)",
+                textTransform: "uppercase",
+                letterSpacing: "0.05em",
+              }}
+            >
+              FIO API Key <span style={{ textTransform: "none", opacity: 0.7 }}>(local storage only)</span>
+            </label>
+            <input
+              type="password"
+              value={fioApiKey}
+              onChange={(e) => setFioApiKey(e.target.value)}
+              className="terminal-input"
+              style={{ width: "100%" }}
+            />
+          </div>
+          <div style={{ display: "flex", flexDirection: "column", gap: "0.25rem" }}>
+            <label
+              style={{
+                fontFamily: "var(--font-mono)",
+                fontSize: "0.7rem",
+                color: "var(--color-text-muted)",
+                textTransform: "uppercase",
+                letterSpacing: "0.05em",
+              }}
+            >
+              Commodity Exchange
+            </label>
+            <select
+              value={selectedExchange}
+              onChange={(e) => setSelectedExchange(e.target.value)}
+              className="terminal-input"
+              style={{ minWidth: "180px" }}
+            >
+              {EXCHANGE_OPTIONS.map((ex) => (
+                <option key={ex.code} value={ex.code}>
+                  {ex.label}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div style={{ display: "flex", flexDirection: "column", gap: "0.25rem" }}>
+            <label
+              style={{
+                fontFamily: "var(--font-mono)",
+                fontSize: "0.7rem",
+                color: "var(--color-text-muted)",
+                textTransform: "uppercase",
+                letterSpacing: "0.05em",
+              }}
+            >
+              Target Days
+            </label>
+            <input
+              type="number"
+              min="1"
+              value={targetDays}
+              onChange={(e) => setTargetDays(e.target.value)}
+              className="terminal-input"
+              style={{ width: "90px", textAlign: "center" }}
+            />
+          </div>
+          <div style={{ display: "flex", flexDirection: "column", gap: "0.25rem" }}>
+            <label
+              style={{
+                fontFamily: "var(--font-mono)",
+                fontSize: "0.7rem",
+                color: "var(--color-text-muted)",
+                textTransform: "uppercase",
+                letterSpacing: "0.05em",
+              }}
+            >
+              Weekly Return %
+            </label>
+            <div style={{ display: "flex", alignItems: "center", gap: "0.5rem" }}>
+              <input
+                type="number"
+                min="0"
+                step="0.5"
+                value={weeklyRate}
+                onChange={(e) => setWeeklyRate(e.target.value)}
+                className="terminal-input"
+                style={{ width: "90px", textAlign: "center" }}
+              />
+              <span
+                style={{
+                  fontFamily: "var(--font-mono)",
+                  fontSize: "0.7rem",
+                  color: "var(--color-text-muted)",
+                  whiteSpace: "nowrap",
+                }}
+              >
+                Return Floor: <span style={{ color: "var(--color-accent-primary)" }}>{returnFloorPct.toFixed(1)}%</span>
+              </span>
+            </div>
+          </div>
+        </div>
+        <div
+          style={{
+            marginTop: "1rem",
+            display: "flex",
+            gap: "1rem",
+            alignItems: "center",
+            flexWrap: "wrap",
+          }}
+        >
+          <button
+            onClick={fetchData}
+            disabled={loading || !hasCredentials}
+            className="terminal-button"
+            style={{ padding: "0.5rem 1.5rem" }}
+          >
+            {loading ? "Fetching..." : "Fetch Data"}
+          </button>
           {!hasCredentials && (
             <span
               style={{
@@ -502,183 +624,74 @@ export default function ResupplyClient() {
               Enter your FIO username and API key
             </span>
           )}
-        </div>
-      </div>
-
-      {/* Exchange Selector */}
-      <div className="terminal-box" style={{ marginBottom: "2rem" }}>
-        <div className="terminal-header" style={{ marginBottom: "1rem" }}>
-          Exchange
-        </div>
-        <select
-          value={selectedExchange}
-          onChange={(e) => setSelectedExchange(e.target.value)}
-          className="terminal-select"
-        >
-          {EXCHANGE_OPTIONS.map((ex) => (
-            <option key={ex.code} value={ex.code}>
-              {ex.label}
-            </option>
-          ))}
-        </select>
-      </div>
-
-      {/* Burn Table + Target Days */}
-      <div className="terminal-box" style={{ marginBottom: "2rem" }}>
-        <div className="terminal-header" style={{ marginBottom: "1rem" }}>
-          Burn Data
-        </div>
-        <div
-          style={{
-            display: "flex",
-            gap: "1rem",
-            flexWrap: "wrap",
-            alignItems: "flex-start",
-          }}
-        >
-          <div style={{ flex: "1 1 400px" }}>
-            <textarea
-              placeholder="Paste burn table from game (select all rows in BUI BRA burn section, copy with Ctrl+C)"
-              value={burnText}
-              onChange={(e) => setBurnText(e.target.value)}
-              className="terminal-input"
-              rows={4}
+          {lastRefresh && (
+            <span
               style={{
-                width: "100%",
-                resize: "vertical",
                 fontFamily: "var(--font-mono)",
                 fontSize: "0.75rem",
+                color: "var(--color-text-muted)",
               }}
-            />
-            {burnText.trim() && (
-              <div
-                style={{
-                  marginTop: "0.5rem",
-                  fontFamily: "var(--font-mono)",
-                  fontSize: "0.75rem",
-                  color: parsedCount > 0
-                    ? "var(--color-text-secondary)"
-                    : "var(--color-error, #ff4444)",
-                }}
-              >
-                {parsedCount > 0
-                  ? `Parsed ${parsedCount} consumption items from Overall`
-                  : "No consumption items found. Ensure burn table has Overall rows with negative Burn/day."}
-              </div>
-            )}
-          </div>
-          <div style={{ display: "flex", gap: "1rem", flexWrap: "wrap" }}>
-            <div style={{ display: "flex", flexDirection: "column", gap: "0.25rem" }}>
-              <label
-                style={{
-                  fontFamily: "var(--font-mono)",
-                  fontSize: "0.7rem",
-                  color: "var(--color-text-muted)",
-                  textTransform: "uppercase",
-                  letterSpacing: "0.05em",
-                }}
-              >
-                Target Days
-              </label>
-              <input
-                type="number"
-                min="1"
-                value={targetDays}
-                onChange={(e) => setTargetDays(e.target.value)}
-                className="terminal-input"
-                style={{ width: "80px", textAlign: "center" }}
-              />
-            </div>
-            <div style={{ display: "flex", flexDirection: "column", gap: "0.25rem" }}>
-              <label
-                style={{
-                  fontFamily: "var(--font-mono)",
-                  fontSize: "0.7rem",
-                  color: "var(--color-text-muted)",
-                  textTransform: "uppercase",
-                  letterSpacing: "0.05em",
-                }}
-              >
-                Weekly Return %
-              </label>
-              <input
-                type="number"
-                min="0"
-                step="0.5"
-                value={weeklyRate}
-                onChange={(e) => setWeeklyRate(e.target.value)}
-                className="terminal-input"
-                style={{ width: "80px", textAlign: "center" }}
-              />
-            </div>
-            <div style={{ display: "flex", flexDirection: "column", gap: "0.25rem" }}>
-              <label
-                style={{
-                  fontFamily: "var(--font-mono)",
-                  fontSize: "0.7rem",
-                  color: "var(--color-text-muted)",
-                  textTransform: "uppercase",
-                  letterSpacing: "0.05em",
-                }}
-              >
-                Ignore Tickers
-              </label>
-              <input
-                type="text"
-                placeholder="e.g. DW, RAT"
-                value={ignoreTickers}
-                onChange={(e) => setIgnoreTickers(e.target.value)}
-                className="terminal-input"
-                style={{ width: "160px" }}
-              />
-            </div>
-          </div>
+            >
+              Last fetch: {lastRefresh.toLocaleTimeString()}
+            </span>
+          )}
         </div>
       </div>
 
-      {/* Controls */}
-      <div
-        style={{
-          marginBottom: "2rem",
-          display: "flex",
-          gap: "1rem",
-          alignItems: "center",
-          flexWrap: "wrap",
-        }}
-      >
-        <button
-          onClick={fetchData}
-          disabled={loading || !hasCredentials}
-          className="terminal-button"
-          style={{ padding: "0.5rem 1.5rem" }}
-        >
-          {loading ? "Fetching..." : "Fetch Data"}
-        </button>
-        {lastRefresh && (
-          <span
+      {/* Burn Data */}
+      <div className="terminal-box" style={{ marginBottom: "2rem" }}>
+        <div className="terminal-header" style={{ marginBottom: "1rem" }}>
+          Paste RPrUn Burn Data
+        </div>
+        <textarea
+          placeholder="Paste burn table from game (select all rows in BUI BRA burn section, copy with Ctrl+C)"
+          value={burnText}
+          onChange={(e) => setBurnText(e.target.value)}
+          className="terminal-input"
+          rows={4}
+          style={{
+            width: "100%",
+            resize: "vertical",
+            fontFamily: "var(--font-mono)",
+            fontSize: "0.75rem",
+          }}
+        />
+        {burnText.trim() && (
+          <div
             style={{
+              marginTop: "0.5rem",
               fontFamily: "var(--font-mono)",
               fontSize: "0.75rem",
-              color: "var(--color-text-muted)",
+              color: parsedCount > 0
+                ? "var(--color-text-secondary)"
+                : "var(--color-error, #ff4444)",
             }}
           >
-            Last fetch: {lastRefresh.toLocaleTimeString()}
-          </span>
+            {parsedCount > 0
+              ? `Parsed ${parsedCount} consumption items from Overall`
+              : "No consumption items found. Ensure burn table has Overall rows with negative Burn/day."}
+          </div>
         )}
-        {rawData && (
-          <button
-            onClick={() => setShowDebug(!showDebug)}
-            className="terminal-button"
-            style={{
-              padding: "0.25rem 0.75rem",
-              fontSize: "0.7rem",
-              marginLeft: "auto",
-              opacity: 0.5,
-            }}
-          >
-            {showDebug ? "Hide Debug" : "Debug"}
-          </button>
-        )}
+      </div>
+
+      {/* Ignore Tickers */}
+      <div className="terminal-box" style={{ marginBottom: "2rem" }}>
+        <div className="terminal-header" style={{ marginBottom: "1rem" }}>
+          Ignore Tickers
+        </div>
+        <textarea
+          placeholder="e.g. DW, RAT, H2O (comma or whitespace separated)"
+          value={ignoreTickers}
+          onChange={(e) => setIgnoreTickers(e.target.value)}
+          className="terminal-input"
+          rows={2}
+          style={{
+            width: "100%",
+            resize: "vertical",
+            fontFamily: "var(--font-mono)",
+            fontSize: "0.75rem",
+          }}
+        />
       </div>
 
       {/* Error */}
@@ -990,8 +1003,8 @@ export default function ResupplyClient() {
                       { label: "Deficit", align: "right" },
                       { label: `Ask (${EXCHANGE_SHORT[selectedExchange]})`, align: "right" },
                       ...EXCHANGE_CODES.map(ex => ({ label: `Bid (${EXCHANGE_SHORT[ex]})`, align: "right" as const })),
-                      { label: "Savings @ Selected", align: "right" },
-                      { label: "Best Savings", align: "right" },
+                      { label: "Savings @ Selected CX", align: "right" },
+                      { label: "Best Savings", align: "center" },
                     ].map((col) => (
                       <th
                         key={col.label}
@@ -1002,7 +1015,7 @@ export default function ResupplyClient() {
                           textTransform: "uppercase",
                           letterSpacing: "0.05em",
                           color: "var(--color-text-secondary)",
-                          textAlign: col.align as "left" | "right",
+                          textAlign: col.align as "left" | "right" | "center",
                           whiteSpace: "nowrap",
                         }}
                       >
@@ -1078,7 +1091,7 @@ export default function ResupplyClient() {
                           padding: "0.5rem 0.6rem",
                           textAlign: "right",
                           color: (row.bestSavings ?? 0) > 0
-                            ? "var(--color-accent-primary)"
+                            ? "var(--color-success, #44ff44)"
                             : "var(--color-text-muted)",
                         }}
                       >
@@ -1213,27 +1226,6 @@ export default function ResupplyClient() {
         </div>
       )}
 
-      {/* Debug View */}
-      {rawData && showDebug && (
-        <div className="terminal-box" style={{ marginBottom: "2rem" }}>
-          <div className="terminal-header" style={{ marginBottom: "1rem" }}>
-            Raw API Response
-          </div>
-          <pre
-            style={{
-              fontFamily: "var(--font-mono)",
-              fontSize: "0.7rem",
-              color: "var(--color-text-secondary)",
-              overflow: "auto",
-              maxHeight: "500px",
-              whiteSpace: "pre-wrap",
-              wordBreak: "break-all",
-            }}
-          >
-            {JSON.stringify(rawData, null, 2)}
-          </pre>
-        </div>
-      )}
     </>
   );
 }

--- a/app/resupply/ResupplyClient.tsx
+++ b/app/resupply/ResupplyClient.tsx
@@ -1,0 +1,296 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import { usePersistedSettings } from "@/hooks/usePersistedSettings";
+
+const EXCHANGE_OPTIONS = [
+  { code: "AI1", label: "Antares Station (AI1)" },
+  { code: "NC1", label: "Moria Station (NC1)" },
+  { code: "CI1", label: "Benten Station (CI1)" },
+  { code: "IC1", label: "Hortus Station (IC1)" },
+];
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type RawData = Record<string, any>;
+
+export default function ResupplyClient() {
+  const [rawData, setRawData] = useState<RawData | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [showDebug, setShowDebug] = useState(false);
+  const [lastRefresh, setLastRefresh] = useState<Date | null>(null);
+
+  const [fioUsername, setFioUsername] = usePersistedSettings<string>(
+    "prun:fio:username",
+    "",
+    { updateUrl: false }
+  );
+  const [fioApiKey, setFioApiKey] = usePersistedSettings<string>(
+    "prun:fio:apiKey",
+    "",
+    { updateUrl: false }
+  );
+  const [selectedExchange, setSelectedExchange] = usePersistedSettings<string>(
+    "prun:resupply:exchange",
+    "AI1",
+    { updateUrl: false }
+  );
+
+  const hasCredentials = fioUsername.trim() !== "" && fioApiKey.trim() !== "";
+
+  const fetchData = useCallback(async () => {
+    if (!fioUsername.trim() || !fioApiKey.trim()) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/resupply", {
+        headers: {
+          "x-fio-username": fioUsername.trim(),
+          "x-fio-api-key": fioApiKey.trim(),
+        },
+      });
+      const json = await res.json();
+      if (json.error) {
+        setError(json.error);
+      } else {
+        setRawData(json);
+        setLastRefresh(new Date());
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to fetch data");
+    } finally {
+      setLoading(false);
+    }
+  }, [fioUsername, fioApiKey]);
+
+  useEffect(() => {
+    if (hasCredentials) fetchData();
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  return (
+    <>
+      {/* Header */}
+      <div className="terminal-box" style={{ marginBottom: "2rem" }}>
+        <h1
+          className="terminal-header"
+          style={{ margin: 0, fontSize: "1.2rem" }}
+        >
+          RESUPPLY // BID_OPPORTUNITY_SCANNER
+        </h1>
+        <p
+          style={{
+            marginTop: "1rem",
+            marginBottom: 0,
+            color: "var(--color-text-secondary)",
+            fontSize: "0.875rem",
+            lineHeight: "1.6",
+          }}
+        >
+          Parses your burn data to find materials you need, checks warehouse
+          supply, and compares ask vs. bid prices across exchanges to surface
+          profitable bidding opportunities.
+          <span
+            className="text-mono"
+            style={{
+              display: "block",
+              marginTop: "0.5rem",
+              fontSize: "0.75rem",
+              color: "var(--color-text-muted)",
+            }}
+          >
+            Source: rest.fnar.net — warehouses + storage + exchange/all + cxos
+          </span>
+        </p>
+      </div>
+
+      {/* FIO Credentials */}
+      <div className="terminal-box" style={{ marginBottom: "2rem" }}>
+        <div className="terminal-header" style={{ marginBottom: "1rem" }}>
+          FIO Credentials
+        </div>
+        <div
+          style={{
+            display: "flex",
+            gap: "1rem",
+            flexWrap: "wrap",
+            alignItems: "center",
+          }}
+        >
+          <input
+            type="text"
+            placeholder="FIO username"
+            value={fioUsername}
+            onChange={(e) => setFioUsername(e.target.value)}
+            className="terminal-input"
+            style={{ flex: 1, minWidth: "150px", maxWidth: "250px" }}
+          />
+          <input
+            type="password"
+            placeholder="FIO API key"
+            value={fioApiKey}
+            onChange={(e) => setFioApiKey(e.target.value)}
+            className="terminal-input"
+            style={{ flex: 2, minWidth: "250px", maxWidth: "450px" }}
+          />
+          {!hasCredentials && (
+            <span
+              style={{
+                fontFamily: "var(--font-mono)",
+                fontSize: "0.75rem",
+                color: "var(--color-text-muted)",
+              }}
+            >
+              Enter your FIO username and API key
+            </span>
+          )}
+        </div>
+      </div>
+
+      {/* Exchange Selector */}
+      <div className="terminal-box" style={{ marginBottom: "2rem" }}>
+        <div className="terminal-header" style={{ marginBottom: "1rem" }}>
+          Exchange
+        </div>
+        <select
+          value={selectedExchange}
+          onChange={(e) => setSelectedExchange(e.target.value)}
+          className="terminal-select"
+        >
+          {EXCHANGE_OPTIONS.map((ex) => (
+            <option key={ex.code} value={ex.code}>
+              {ex.label}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      {/* Controls */}
+      <div
+        style={{
+          marginBottom: "2rem",
+          display: "flex",
+          gap: "1rem",
+          alignItems: "center",
+          flexWrap: "wrap",
+        }}
+      >
+        <button
+          onClick={fetchData}
+          disabled={loading || !hasCredentials}
+          className="terminal-button"
+          style={{ padding: "0.5rem 1.5rem" }}
+        >
+          {loading ? "Fetching..." : "Fetch Data"}
+        </button>
+        {lastRefresh && (
+          <span
+            style={{
+              fontFamily: "var(--font-mono)",
+              fontSize: "0.75rem",
+              color: "var(--color-text-muted)",
+            }}
+          >
+            Last fetch: {lastRefresh.toLocaleTimeString()}
+          </span>
+        )}
+        {rawData && (
+          <button
+            onClick={() => setShowDebug(!showDebug)}
+            className="terminal-button"
+            style={{
+              padding: "0.25rem 0.75rem",
+              fontSize: "0.7rem",
+              marginLeft: "auto",
+              opacity: 0.5,
+            }}
+          >
+            {showDebug ? "Hide Debug" : "Debug"}
+          </button>
+        )}
+      </div>
+
+      {/* Error */}
+      {error && (
+        <div
+          className="terminal-box"
+          style={{
+            marginBottom: "2rem",
+            borderColor: "var(--color-error, #ff4444)",
+          }}
+        >
+          <div
+            style={{
+              color: "var(--color-error, #ff4444)",
+              fontFamily: "var(--font-mono)",
+              fontSize: "0.875rem",
+            }}
+          >
+            [ERROR] {error}
+          </div>
+        </div>
+      )}
+
+      {/* Data Summary */}
+      {rawData && !showDebug && (
+        <div className="terminal-box" style={{ marginBottom: "2rem" }}>
+          <div className="terminal-header" style={{ marginBottom: "1rem" }}>
+            Data Loaded
+          </div>
+          <div
+            style={{
+              fontFamily: "var(--font-mono)",
+              fontSize: "0.8rem",
+              color: "var(--color-text-secondary)",
+              lineHeight: "1.8",
+            }}
+          >
+            <div>
+              Warehouses: {Array.isArray(rawData.warehouses) ? rawData.warehouses.length : 0} entries
+            </div>
+            <div>
+              Storage: {Array.isArray(rawData.storage) ? rawData.storage.length : 0} entries
+            </div>
+            <div>
+              Exchange tickers: {Array.isArray(rawData.exchangeData) ? rawData.exchangeData.length : 0} entries
+            </div>
+            <div>
+              Open orders: {Array.isArray(rawData.orders) ? rawData.orders.length : 0} entries
+            </div>
+            <div
+              style={{
+                marginTop: "1rem",
+                color: "var(--color-text-muted)",
+                fontSize: "0.75rem",
+              }}
+            >
+              Phase 1 complete. Burn table parsing and deficit calculation coming
+              in Phase 2.
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Debug View */}
+      {rawData && showDebug && (
+        <div className="terminal-box" style={{ marginBottom: "2rem" }}>
+          <div className="terminal-header" style={{ marginBottom: "1rem" }}>
+            Raw API Response
+          </div>
+          <pre
+            style={{
+              fontFamily: "var(--font-mono)",
+              fontSize: "0.7rem",
+              color: "var(--color-text-secondary)",
+              overflow: "auto",
+              maxHeight: "500px",
+              whiteSpace: "pre-wrap",
+              wordBreak: "break-all",
+            }}
+          >
+            {JSON.stringify(rawData, null, 2)}
+          </pre>
+        </div>
+      )}
+    </>
+  );
+}

--- a/app/resupply/ResupplyClient.tsx
+++ b/app/resupply/ResupplyClient.tsx
@@ -462,6 +462,94 @@ export default function ResupplyClient() {
         </p>
       </div>
 
+      {/* Burn Data */}
+      <div className="terminal-box" style={{ marginBottom: "2rem" }}>
+        <div className="terminal-header" style={{ marginBottom: "1rem" }}>
+          Burn Data
+        </div>
+        <div
+          style={{
+            display: "flex",
+            gap: "1rem",
+            flexWrap: "wrap",
+            alignItems: "flex-start",
+          }}
+        >
+          <div style={{ flex: "3 1 0", minWidth: "300px" }}>
+            <label
+              style={{
+                display: "block",
+                fontFamily: "var(--font-mono)",
+                fontSize: "0.7rem",
+                color: "var(--color-text-muted)",
+                textTransform: "uppercase",
+                letterSpacing: "0.05em",
+                marginBottom: "0.25rem",
+              }}
+            >
+              Paste RPrUn Burn Data
+            </label>
+            <textarea
+              placeholder="Paste burn table from game (select all rows in BUI BRA burn section, copy with Ctrl+C)"
+              value={burnText}
+              onChange={(e) => setBurnText(e.target.value)}
+              className="terminal-input"
+              rows={4}
+              style={{
+                width: "100%",
+                resize: "vertical",
+                fontFamily: "var(--font-mono)",
+                fontSize: "0.75rem",
+              }}
+            />
+            {burnText.trim() && (
+              <div
+                style={{
+                  marginTop: "0.5rem",
+                  fontFamily: "var(--font-mono)",
+                  fontSize: "0.75rem",
+                  color: parsedCount > 0
+                    ? "var(--color-text-secondary)"
+                    : "var(--color-error, #ff4444)",
+                }}
+              >
+                {parsedCount > 0
+                  ? `Parsed ${parsedCount} consumption items from Overall`
+                  : "No consumption items found. Ensure burn table has Overall rows with negative Burn/day."}
+              </div>
+            )}
+          </div>
+          <div style={{ flex: "1 1 0", minWidth: "140px" }}>
+            <label
+              style={{
+                display: "block",
+                fontFamily: "var(--font-mono)",
+                fontSize: "0.7rem",
+                color: "var(--color-text-muted)",
+                textTransform: "uppercase",
+                letterSpacing: "0.05em",
+                marginBottom: "0.25rem",
+              }}
+            >
+              Ignore Tickers
+            </label>
+            <textarea
+              placeholder="e.g. DW, RAT, H2O"
+              value={ignoreTickers}
+              onChange={(e) => setIgnoreTickers(e.target.value)}
+              className="terminal-input"
+              rows={4}
+              style={{
+                width: "100%",
+                resize: "vertical",
+                fontFamily: "var(--font-mono)",
+                fontSize: "0.75rem",
+              }}
+            />
+          </div>
+        </div>
+      </div>
+
       {/* Settings */}
       <div className="terminal-box" style={{ marginBottom: "2rem" }}>
         <div className="terminal-header" style={{ marginBottom: "1rem" }}>
@@ -636,62 +724,6 @@ export default function ResupplyClient() {
             </span>
           )}
         </div>
-      </div>
-
-      {/* Burn Data */}
-      <div className="terminal-box" style={{ marginBottom: "2rem" }}>
-        <div className="terminal-header" style={{ marginBottom: "1rem" }}>
-          Paste RPrUn Burn Data
-        </div>
-        <textarea
-          placeholder="Paste burn table from game (select all rows in BUI BRA burn section, copy with Ctrl+C)"
-          value={burnText}
-          onChange={(e) => setBurnText(e.target.value)}
-          className="terminal-input"
-          rows={4}
-          style={{
-            width: "100%",
-            resize: "vertical",
-            fontFamily: "var(--font-mono)",
-            fontSize: "0.75rem",
-          }}
-        />
-        {burnText.trim() && (
-          <div
-            style={{
-              marginTop: "0.5rem",
-              fontFamily: "var(--font-mono)",
-              fontSize: "0.75rem",
-              color: parsedCount > 0
-                ? "var(--color-text-secondary)"
-                : "var(--color-error, #ff4444)",
-            }}
-          >
-            {parsedCount > 0
-              ? `Parsed ${parsedCount} consumption items from Overall`
-              : "No consumption items found. Ensure burn table has Overall rows with negative Burn/day."}
-          </div>
-        )}
-      </div>
-
-      {/* Ignore Tickers */}
-      <div className="terminal-box" style={{ marginBottom: "2rem" }}>
-        <div className="terminal-header" style={{ marginBottom: "1rem" }}>
-          Ignore Tickers
-        </div>
-        <textarea
-          placeholder="e.g. DW, RAT, H2O (comma or whitespace separated)"
-          value={ignoreTickers}
-          onChange={(e) => setIgnoreTickers(e.target.value)}
-          className="terminal-input"
-          rows={2}
-          style={{
-            width: "100%",
-            resize: "vertical",
-            fontFamily: "var(--font-mono)",
-            fontSize: "0.75rem",
-          }}
-        />
       </div>
 
       {/* Error */}

--- a/docs/resupply-plan.md
+++ b/docs/resupply-plan.md
@@ -4,11 +4,20 @@
 
 Users need to determine if placing bids (buy orders) for needed supply materials at commodity exchanges is financially worthwhile compared to buying at ask price. This feature parses a user's planetary burn data, checks their existing warehouse supply and open orders, then compares ask vs. bid prices across all 4 exchanges to surface profitable bidding opportunities ranked by net savings.
 
+## Why This Plan Is Phased
+
+The original plan specified the entire client component as a single stage. That's ~800+ lines of interleaved computation logic and UI with 6 tightly coupled computation steps, 8 input controls, a multi-exchange comparison table, a stale bids section, and summary stats. By contrast, the existing `BidUpdateClient.tsx` is 615 lines with computation done server-side.
+
+Breaking into phases means each step is:
+- Small enough to implement correctly in one pass (~150-250 new lines)
+- Independently testable before moving on
+- Building on verified working code from the previous phase
+
 ## Files to Create
 
-1. **`/app/resupply/page.tsx`** — Server page wrapper (boilerplate, same pattern as `/app/bid-update/page.tsx`)
-2. **`/app/resupply/ResupplyClient.tsx`** — Main client component with all UI and computation logic
-3. **`/app/api/resupply/route.ts`** — API route that proxies 4 FIO API calls
+1. **`/app/api/resupply/route.ts`** — API route that proxies 4 FIO API calls
+2. **`/app/resupply/page.tsx`** — Server page wrapper (boilerplate)
+3. **`/app/resupply/ResupplyClient.tsx`** — Main client component (built incrementally across phases)
 
 No modifications to existing files (nav not updated per user preference; page accessed via direct URL).
 
@@ -19,9 +28,36 @@ No modifications to existing files (nav not updated per user preference; page ac
 
 This avoids sending the burn table to the server and allows instant parameter tweaking.
 
+## Shared Reference: Input Controls
+
+All controls across all phases use `terminal-box` containers with `terminal-input`, `terminal-select`, `terminal-button` classes. All persisted settings use `usePersistedSettings` hook from `/src/hooks/usePersistedSettings.ts` with `{ updateUrl: false }`.
+
+| Control | Type | Default | Persisted Key | Added In |
+|---------|------|---------|---------------|----------|
+| FIO Username | text input | "" | `prun:fio:username` (shared) | Phase 1 |
+| FIO API Key | password input | "" | `prun:fio:apiKey` (shared) | Phase 1 |
+| Commodity Exchange | dropdown (select) | "AI1" | `prun:resupply:exchange` | Phase 1 |
+| Burn Table | textarea (~4 rows visible) | "" | Not persisted | Phase 2 |
+| Target Days of Supply | number input | 14 | `prun:resupply:targetDays` | Phase 2 |
+| Weekly Return Floor % | number input | 3 | `prun:resupply:weeklyRate` | Phase 3 |
+| Ignore Tickers | text input | "" | `prun:resupply:ignoreTickers` | Phase 3 |
+| Min Savings (at table top) | number input | 0 | `prun:resupply:minSavings` | Phase 3 |
+
+Exchange dropdown options:
+- Antares Station → code `AI1`
+- Moria Station → code `NC1`
+- Benten Station → code `CI1`
+- Hortus Station → code `IC1`
+
 ---
 
-## 1. API Route (`/app/api/resupply/route.ts`)
+## Phase 1: API Route + Page Scaffold + Data Fetch
+
+**Goal**: Get the API route working and display raw data on the page. Verify the server-side plumbing end to end before writing any computation logic.
+
+**Delivers**: A page at `/resupply` with credential inputs, an exchange dropdown, a fetch button, and a raw JSON debug view of the API response.
+
+### 1a. API Route (`/app/api/resupply/route.ts`)
 
 **Pattern**: Follow `/app/api/bid-update/route.ts` exactly.
 
@@ -48,9 +84,7 @@ This avoids sending the burn table to the server and allows instant parameter tw
 
 **Error handling**: Check each response `.ok`, return 502 on FIO failure, 500 on unexpected error.
 
----
-
-## 2. Server Page Wrapper (`/app/resupply/page.tsx`)
+### 1b. Server Page Wrapper (`/app/resupply/page.tsx`)
 
 Standard boilerplate:
 ```typescript
@@ -61,44 +95,41 @@ export const revalidate = 0;
 export default function ResupplyPage() { return <ResupplyClient />; }
 ```
 
----
+### 1c. Client Skeleton (`ResupplyClient.tsx` — initial version)
 
-## 3. Client Component (`/app/resupply/ResupplyClient.tsx`)
+**Controls added this phase**: FIO Username, FIO API Key, Commodity Exchange dropdown, Fetch button.
 
-### 3a. Input Controls Section
-
-All in `terminal-box` containers using `terminal-input`, `terminal-select`, `terminal-button` classes.
-
-| Control | Type | Default | Persisted Key |
-|---------|------|---------|---------------|
-| FIO Username | text input | "" | `prun:fio:username` (shared) |
-| FIO API Key | password input | "" | `prun:fio:apiKey` (shared) |
-| Commodity Exchange | dropdown (select) | "AI1" | `prun:resupply:exchange` |
-| Target Days of Supply | number input | 14 | `prun:resupply:targetDays` |
-| Weekly Return Floor % | number input | 3 | `prun:resupply:weeklyRate` |
-| Ignore Tickers | text input | "" | `prun:resupply:ignoreTickers` |
-| Burn Table | textarea (short height, ~4 rows visible) | "" | Not persisted |
-| Min Savings (at table top) | number input | 0 | `prun:resupply:minSavings` |
-
-Exchange dropdown options:
-- Antares Station → code `AI1`
-- Moria Station → code `NC1`
-- Benten Station → code `CI1`
-- Hortus Station → code `IC1`
-
-All persisted settings use `usePersistedSettings` hook from `/src/hooks/usePersistedSettings.ts` with `{ updateUrl: false }`.
-
-Burn table textarea should show a small preview area (~4 rows) with a parsed count below: e.g. "Parsed 45 consumption items from Overall".
-
-### 3b. Data Fetch (`fetchData` callback)
-
+**Data fetch** (`fetchData` callback):
 - `GET /api/resupply` with credential headers
 - Store raw response in `rawData` state
 - Same pattern as `BidUpdateClient.tsx` lines 76-99
 
-### 3c. Core Computation (`useMemo`)
+**Display**: Show loading state, error state, and a `<pre>` block with `JSON.stringify(rawData, null, 2)` so you can visually confirm all 4 API responses contain real data.
 
-Depends on: `rawData`, `burnText`, `selectedExchange`, `targetDays`, `weeklyRate`, `ignoreTickers`
+### Phase 1 Verification
+
+1. Run `npm run dev`, navigate to `/resupply`
+2. Enter credentials, click fetch
+3. Confirm raw JSON shows populated `warehouses`, `storage`, `exchangeData`, `orders` arrays
+4. Confirm 502 error displays correctly when using bad credentials
+
+---
+
+## Phase 2: Burn Table Parsing + Deficit Table
+
+**Goal**: Parse the user's burn table, match warehouse inventory at the selected exchange, and show a simple deficit table. This is the core data pipeline — get it right before adding pricing.
+
+**Delivers**: A table showing Ticker | Demand | On-Hand | Deficit for each consumed material.
+
+### 2a. New Controls
+
+Add to the input section: Burn Table textarea, Target Days of Supply input.
+
+Burn table textarea should show a small preview area (~4 rows) with a parsed count below: e.g. "Parsed 45 consumption items from Overall".
+
+### 2b. Computation (`useMemo` — first block)
+
+Depends on: `rawData`, `burnText`, `selectedExchange`, `targetDays`
 
 **Step 1 — Parse burn table**:
 - Split by newlines, split each by `\t`
@@ -115,27 +146,56 @@ Depends on: `rawData`, `burnText`, `selectedExchange`, `targetDays`, `weeklyRate
 
 **Step 3 — Compute raw deficits**:
 - For each burn ticker: `deficit = demand - (onHandMap.get(ticker) || 0)`
-- Exclude ignored tickers and tickers with deficit <= 0
+- Keep all rows (including deficit <= 0) so the user can verify the math
+- Mark rows with deficit <= 0 as "stocked" visually (dimmed)
+
+### 2c. Deficit Table
+
+Simple table replacing the raw JSON debug view:
+
+| Column | Content |
+|--------|---------|
+| Ticker | Material ticker code |
+| Demand | `abs(burnPerDay) * targetDays` |
+| On-Hand | Warehouse quantity at selected exchange |
+| Deficit | `demand - onHand` (or "Stocked" if <= 0) |
+
+### Phase 2 Verification
+
+1. Paste burn data into textarea, confirm "Parsed N consumption items" count
+2. Verify demand = `abs(burn/day) * targetDays` for a few tickers manually
+3. Switch exchange dropdown — on-hand values should update (different warehouse)
+4. Change target days — demand and deficit columns should recalculate instantly (no re-fetch)
+5. Tickers with sufficient on-hand should show as "Stocked"
+
+---
+
+## Phase 3: Price Comparison + Savings Table
+
+**Goal**: Add exchange price lookups, the `incrementBid` function, and the full savings comparison across all 4 exchanges. This is the main value of the feature.
+
+**Delivers**: The full results table with bid prices, savings, and return % across exchanges.
+
+### 3a. New Controls
+
+Add: Weekly Return Floor %, Ignore Tickers text input, Min Savings filter (above the table).
+
+### 3b. Computation (extend `useMemo`)
+
+Depends on (new): `weeklyRate`, `ignoreTickers`
 
 **Step 4 — Build exchange price lookups**:
 - `askMap: Map<"TICKER.EXCHANGE", askPrice>`
 - `bidMap: Map<"TICKER.EXCHANGE", bidPrice>`
 - From `rawData.exchangeData`, same pattern as bid-update route lines 104-113
 
-**Step 5 — Process user orders (stale bids + top bid deductions)**:
-- Filter orders: `OrderType === "BUYING"` AND `Status in ("PLACED", "PARTIALLY_FILLED")`
-- For each active buy order, look up market bid for that `ticker.exchange`:
-  - If `order.Limit === marketBid` → user has top bid → track for deficit deduction
-  - If `order.Limit !== marketBid` → stale bid → add to stale bids list
-- Deduct top-bid amounts from deficits (only at the ticker level, regardless of exchange, since the user's existing order covers that quantity)
-
-**Step 6 — Compute resupply rows**:
+**Step 5 — Compute resupply rows**:
 - Required return threshold = `(1 + weeklyRate/100)^(targetDays/7) - 1`
+- Filter out ignored tickers and tickers with deficit <= 0
 - For each ticker with remaining deficit > 0:
   - Get `askAtSelected = askMap.get("TICKER.selectedExchange")`
   - For each of the 4 exchanges, compute the effective bid price:
-    - If user has top bid at that exchange → use their limit price
-    - Else → `incrementBid(marketBid)` (increment 3rd significant figure)
+    - `incrementBid(marketBid)` (increment 3rd significant figure)
   - Per-unit savings = `askAtSelected - effectiveBidPrice`
   - Return % = `(askAtSelected - effectiveBidPrice) / effectiveBidPrice`
   - Net savings = `perUnitSavings * deficit`
@@ -152,11 +212,10 @@ Round to avoid floating point artifacts
 ```
 Examples: 10.1→10.2, 1020→1030, 99→100, 0.5→0.501
 
-### 3d. Results Table
+### 3c. Results Table
 
-Filtered by minimum total net savings filter (at table top).
+Replace the simple deficit table with the full results table. Filtered by min savings at the top.
 
-**Columns**:
 | Column | Content |
 |--------|---------|
 | Ticker | Material ticker code |
@@ -171,18 +230,58 @@ Filtered by minimum total net savings filter (at table top).
 
 Ranked by net savings descending. Sortable column headers.
 
-### 3e. Stale Bids Section
+### Phase 3 Verification
+
+1. Verify ask prices match the selected exchange
+2. Verify bid columns show market bid for each exchange
+3. Pick a ticker, manually compute: `savings = (ask - incrementBid(bid)) * deficit` — should match
+4. Change weekly return floor — rows below threshold should disappear
+5. Add a ticker to ignore list — it should vanish from results
+6. Change min savings — low-savings rows should filter out
+7. Switch exchange — ask prices and savings should recalculate
+
+---
+
+## Phase 4: Order Integration + Stale Bids + Summary
+
+**Goal**: Account for the user's existing open orders. Deduct active top bids from deficits, flag stale bids for cleanup, and add summary stats.
+
+**Delivers**: Final polished feature with order-aware deficits, stale bid warnings, and summary boxes.
+
+### 4a. Computation (extend `useMemo` — insert between Steps 4 and 5)
+
+**New Step — Process user orders (stale bids + top bid deductions)**:
+- Filter orders: `OrderType === "BUYING"` AND `Status in ("PLACED", "PARTIALLY_FILLED")`
+- For each active buy order, look up market bid for that `ticker.exchange`:
+  - If `order.Limit === marketBid` → user has top bid → track for deficit deduction
+  - If `order.Limit !== marketBid` → stale bid → add to stale bids list
+- Deduct top-bid amounts from deficits (only at the ticker level, regardless of exchange, since the user's existing order covers that quantity)
+
+**Update to resupply row computation** (existing Step 5):
+- When computing effective bid price per exchange:
+  - If user has top bid at that exchange → use their limit price (already the top bid)
+  - Else → `incrementBid(marketBid)` as before
+
+### 4b. Stale Bids Section
 
 Separate `terminal-box` with warning styling, shown only when stale bids exist.
 Table columns: Ticker, Exchange, My Limit, Market Bid, Amount.
 Purpose: Alert user to remove/update these orders in-game.
 
-### 3f. Summary Stats
+### 4c. Summary Stats
 
 Row of stat boxes (same visual pattern as bid-update):
 - Total deficit tickers analyzed
 - Total potential savings
 - Stale bid count
+
+### Phase 4 Verification
+
+1. If user has open buy orders, verify stale ones (limit ≠ market bid) appear in stale bids section
+2. Verify top-bid orders reduce the deficit amount for that ticker
+3. Verify that tickers where the user already covers the full deficit via existing orders are excluded
+4. Verify summary stats match the table data
+5. Full golden path: credentials → paste burn data → review deficits → review savings → check stale bids
 
 ---
 
@@ -197,17 +296,3 @@ Row of stat boxes (same visual pattern as bid-update):
 | Exchange labels (AI1→ANT etc.) | `/app/bid-update/BidUpdateClient.tsx` lines 37-42 |
 | Client fetch + error/loading pattern | `/app/bid-update/BidUpdateClient.tsx` lines 76-99 |
 | Terminal CSS classes | `/app/globals.css` |
-
----
-
-## Verification Plan
-
-1. **API route**: After creating, test with curl or browser devtools — verify all 4 FIO responses return data
-2. **Burn table parsing**: Paste the example burn data; verify "Parsed N consumption items from Overall" count matches expected (items with negative Burn/day under Overall)
-3. **Deficit calculation**: Manually verify a couple tickers: demand = abs(burn/day) * targetDays - onHand - existingTopBidAmount
-4. **Stale bids**: If user has open orders, verify stale ones appear in the stale bids section
-5. **Savings math**: Pick a ticker, verify: savings = (ask - incrementedBid) * deficit, return % = (ask - incrementedBid) / incrementedBid
-6. **Filters**: Change min savings, weekly rate, target days — verify table updates instantly without re-fetch
-7. **Exchange switching**: Switch dropdown — verify ask prices, on-hand supply, and savings recalculate
-8. **Ignore tickers**: Add a ticker to ignore list — verify it disappears from results
-9. **Dev server**: Run `npm run dev`, navigate to `/resupply`, test full golden path


### PR DESCRIPTION
## Summary

Implements a new resupply tool that helps users identify profitable bidding opportunities across commodity exchanges. The tool parses planetary burn data, checks warehouse inventory, and compares ask vs. bid prices to surface materials worth bidding on based on return thresholds.

## Changes

### New Files
- **`/app/resupply/ResupplyClient.tsx`** (1263 lines) — Main client component with complete UI and computation logic
  - Burn table parsing to extract material consumption rates
  - Warehouse inventory lookup at selected exchange
  - Multi-exchange price comparison with effective bid calculation
  - Stale bid detection for existing orders
  - Savings and return % calculations
  - Responsive terminal-style UI with multiple data tables

- **`/app/resupply/page.tsx`** — Server page wrapper (boilerplate)

- **`/app/api/resupply/route.ts`** — API route that proxies 4 FIO API calls
  - Fetches warehouses, storage, exchange data, and open orders
  - Aggregates responses into single JSON payload
  - Proper error handling with 502 on FIO failures

### Documentation
- **`docs/resupply-plan.md`** — Updated with phased implementation approach and detailed specifications

## Key Features

- **Burn Data Parsing**: Extracts consumption rates from game burn tables (Overall rows with negative burn/day)
- **Inventory Matching**: Looks up on-hand quantities at the selected commodity exchange warehouse
- **Multi-Exchange Comparison**: Calculates effective bids (market bid + 1 increment, or user's existing top bid) across all 4 exchanges
- **Return Floor Filtering**: Compounds weekly return % over target days to determine minimum acceptable return
- **Stale Bid Detection**: Identifies buy orders where limit price no longer matches market bid
- **Savings Calculation**: Computes net savings (ask price - effective bid) × deficit quantity
- **Configurable Filters**: Min savings threshold, ignore ticker list, target days, weekly return %

## Implementation Details

- Uses `usePersistedSettings` hook for all user preferences (stored in localStorage)
- Credential headers passed to API route, not stored in URL
- Burn table not sent to server — all parsing happens client-side
- Bid increment logic: increments at 3rd significant figure (10.1→10.2, 1020→1030, etc.)
- Tables sorted by best net savings descending
- Responsive layout with terminal-style styling matching existing design system

https://claude.ai/code/session_011u1qXLLSG7uXmB38cnqbyf