### PR TITLE
Disable daily schedule for monitoring snapshot workflow

### DIFF
--- a/.github/workflows/daily-monitoring-snapshot.yml
+++ b/.github/workflows/daily-monitoring-snapshot.yml
@@ -1,9 +1,6 @@
 name: Daily Monitoring Snapshot
 
 on:
-  schedule:
-    - cron: '0 0 * * *'  # 0:00 UTC daily
-
   workflow_dispatch:
     inputs:
       date_override:


### PR DESCRIPTION
Remove the daily cron schedule (0 0 * * *) that was running the monitoring
snapshot at midnight UTC. The workflow can still be triggered manually via
workflow_dispatch if needed.

https://claude.ai/code/session_016qYuLtCPn5oDUC7vYFPHJ5