### PR TITLE
Add buy-all profit tracking and optimize snapshot fetching

### DIFF
--- a/app/api/best-recipes/history/route.ts
+++ b/app/api/best-recipes/history/route.ts
@@ -122,22 +122,22 @@ export async function GET(request: Request) {
       getTimestampMillis(b.timestamp) - getTimestampMillis(a.timestamp)
     ).slice(0, limit);
 
-    // Fetch all snapshots in parallel
-    const snapshotPromises = snapshots.map(async (snapshot) => {
-      const snapshotUrl = `${GCS_BUCKET}/historical/${configName}/${snapshot.timestamp}.json`;
+    // Fetch snapshots with bounded concurrency (avoids saturating the HTTP connection pool)
+    const CONCURRENCY = 25;
+    const results: (Awaited<ReturnType<typeof fetchSnapshot>> )[] = [];
 
+    async function fetchSnapshot(snapshot: IndexEntry) {
+      const snapshotUrl = `${GCS_BUCKET}/historical/${configName}/${snapshot.timestamp}.json`;
       try {
-        const snapshotResponse = await fetch(snapshotUrl, { cache: "no-store" });
+        // Snapshots are immutable once written — cache aggressively at the Next.js layer
+        const snapshotResponse = await fetch(snapshotUrl, { next: { revalidate: 86400 } });
         if (!snapshotResponse.ok) {
           console.warn(`Failed to fetch snapshot ${snapshot.timestamp}: ${snapshotResponse.status}`);
           return null;
         }
-
         const snapshotData: BestRecipeResult[] = await snapshotResponse.json();
         const tickerData = snapshotData.find(item => item.ticker === ticker);
-
         if (!tickerData) return null;
-
         return {
           timestamp: snapshot.timestamp,
           recipeId: tickerData.recipeId,
@@ -150,10 +150,13 @@ export async function GET(request: Request) {
         console.warn(`Error processing snapshot ${snapshot.timestamp}:`, err.message);
         return null;
       }
-    });
+    }
 
-    // Fetch all in parallel
-    const results = await Promise.all(snapshotPromises);
+    for (let i = 0; i < snapshots.length; i += CONCURRENCY) {
+      const batch = snapshots.slice(i, i + CONCURRENCY);
+      const batchResults = await Promise.all(batch.map(fetchSnapshot));
+      results.push(...batchResults);
+    }
 
     // Filter out nulls and sort by timestamp ascending
     const validSnapshots = results

--- a/app/best-recipes-history/BestRecipesHistoryClient.tsx
+++ b/app/best-recipes-history/BestRecipesHistoryClient.tsx
@@ -289,6 +289,16 @@ export default function BestRecipesHistoryClient() {
     ).length,
   } : null;
 
+  // Calculate stats for buy-all profit history (excludes null entries)
+  const buyAllHistoryData = historyData.filter(h => h.buyAllProfitPA !== null) as (HistoricalSnapshot & { buyAllProfitPA: number })[];
+  const buyAllHistoryStats = buyAllHistoryData.length > 0 ? {
+    current: buyAllHistoryData[buyAllHistoryData.length - 1].buyAllProfitPA,
+    oldest: buyAllHistoryData[0].buyAllProfitPA,
+    max: Math.max(...buyAllHistoryData.map(h => h.buyAllProfitPA)),
+    min: Math.min(...buyAllHistoryData.map(h => h.buyAllProfitPA)),
+    avg: buyAllHistoryData.reduce((sum, h) => sum + h.buyAllProfitPA, 0) / buyAllHistoryData.length,
+  } : null;
+
   return (
     <div className="terminal-container">
       {/* Header Section */}
@@ -607,6 +617,9 @@ export default function BestRecipesHistoryClient() {
 
             {/* Chart */}
             <div style={{ marginBottom: "1.5rem" }}>
+              <h3 style={{ color: "var(--color-text-secondary)", fontSize: "0.875rem", marginBottom: "0.75rem", textTransform: "uppercase", letterSpacing: "0.05em" }}>
+                Profit P/A — {selectedTicker}
+              </h3>
               <Plot
                 data={[
                   {
@@ -639,6 +652,100 @@ export default function BestRecipesHistoryClient() {
                 config={{ responsive: true }}
                 style={{ width: "100%", height: "400px" }}
               />
+            </div>
+
+            {/* Buy-All Profit Chart */}
+            <div style={{ marginBottom: "1.5rem" }}>
+              <h3 style={{ color: "var(--color-text-secondary)", fontSize: "0.875rem", marginBottom: "0.75rem", textTransform: "uppercase", letterSpacing: "0.05em" }}>
+                Buy-All Profit P/A — {selectedTicker}
+              </h3>
+              {buyAllHistoryStats && (
+                <div
+                  style={{
+                    display: "grid",
+                    gridTemplateColumns: "repeat(auto-fit, minmax(150px, 1fr))",
+                    gap: "1rem",
+                    marginBottom: "1rem",
+                    padding: "1.25rem",
+                    backgroundColor: "var(--color-bg-tertiary)",
+                    border: "1px solid var(--color-border-primary)",
+                    borderRadius: "4px",
+                  }}
+                >
+                  <div>
+                    <div style={{ color: "var(--color-text-muted)", fontSize: "0.75rem" }}>Current Buy-All P/A</div>
+                    <div style={{ color: "var(--color-accent-primary)", fontSize: "1.125rem", fontWeight: "bold" }}>
+                      {formatProfitPerArea(buyAllHistoryStats.current, exchange as Exchange)}
+                    </div>
+                  </div>
+                  <div>
+                    <div style={{ color: "var(--color-text-muted)", fontSize: "0.75rem" }}>Change Since Start</div>
+                    <div
+                      style={{
+                        fontSize: "1.125rem",
+                        fontWeight: "bold",
+                        color: buyAllHistoryStats.current - buyAllHistoryStats.oldest >= 0 ? "var(--color-success)" : "var(--color-error)",
+                      }}
+                    >
+                      {formatChange(buyAllHistoryStats.current - buyAllHistoryStats.oldest)}
+                    </div>
+                  </div>
+                  <div>
+                    <div style={{ color: "var(--color-text-muted)", fontSize: "0.75rem" }}>Average Buy-All P/A</div>
+                    <div style={{ color: "var(--color-text-primary)", fontSize: "1.125rem", fontWeight: "bold" }}>
+                      {formatProfitPerArea(buyAllHistoryStats.avg, exchange as Exchange)}
+                    </div>
+                  </div>
+                  <div>
+                    <div style={{ color: "var(--color-text-muted)", fontSize: "0.75rem" }}>Max Buy-All P/A</div>
+                    <div style={{ color: "var(--color-success)", fontSize: "1.125rem", fontWeight: "bold" }}>
+                      {formatProfitPerArea(buyAllHistoryStats.max, exchange as Exchange)}
+                    </div>
+                  </div>
+                  <div>
+                    <div style={{ color: "var(--color-text-muted)", fontSize: "0.75rem" }}>Min Buy-All P/A</div>
+                    <div style={{ color: "var(--color-error)", fontSize: "1.125rem", fontWeight: "bold" }}>
+                      {formatProfitPerArea(buyAllHistoryStats.min, exchange as Exchange)}
+                    </div>
+                  </div>
+                </div>
+              )}
+              {buyAllHistoryData.length > 0 ? (
+                <Plot
+                  data={[
+                    {
+                      x: buyAllHistoryData.map((h) => h.timestamp),
+                      y: buyAllHistoryData.map((h) => h.buyAllProfitPA),
+                      type: "scatter",
+                      mode: "lines+markers",
+                      marker: { color: "rgb(100, 180, 255)", size: 6 },
+                      line: { color: "rgb(100, 180, 255)", width: 2 },
+                      name: "Buy-All Profit P/A",
+                    },
+                  ]}
+                  layout={{
+                    paper_bgcolor: "rgb(16, 20, 25)",
+                    plot_bgcolor: "rgb(16, 20, 25)",
+                    font: { color: "rgb(230, 232, 235)" },
+                    xaxis: {
+                      title: "Timestamp",
+                      gridcolor: "rgb(42, 63, 95)",
+                      color: "rgb(230, 232, 235)",
+                    },
+                    yaxis: {
+                      title: "Buy-All Profit per Area (P/A)",
+                      gridcolor: "rgb(42, 63, 95)",
+                      color: "rgb(230, 232, 235)",
+                    },
+                    margin: { l: 60, r: 40, t: 40, b: 80 },
+                    hovermode: "closest",
+                  }}
+                  config={{ responsive: true }}
+                  style={{ width: "100%", height: "400px" }}
+                />
+              ) : (
+                <p style={{ color: "var(--color-text-muted)", fontSize: "0.875rem" }}>No buy-all profit data available for this ticker.</p>
+              )}
             </div>
 
             {/* History Table */}


### PR DESCRIPTION
## Summary
This PR adds buy-all profit per area (P/A) visualization and statistics to the best recipes history view, while also optimizing the snapshot fetching logic to prevent connection pool saturation.

## Key Changes

### Frontend (BestRecipesHistoryClient.tsx)
- **New Buy-All Profit Stats**: Added calculation of buy-all profit statistics (current, oldest, max, min, average) from historical data
- **Buy-All Profit Chart**: Implemented a new chart section displaying buy-all profit P/A trends over time with:
  - Statistics grid showing current value, change since start, average, max, and min
  - Interactive line chart with markers
  - Fallback message when no data is available
- **Chart Labels**: Added descriptive headers to both the existing profit chart and new buy-all profit chart

### Backend (best-recipes/history/route.ts)
- **Bounded Concurrency**: Replaced unbounded `Promise.all()` with a batched approach using a concurrency limit of 25 to prevent HTTP connection pool exhaustion
- **Aggressive Caching**: Changed snapshot fetching from `cache: "no-store"` to `next: { revalidate: 86400 }` (24-hour cache) since snapshots are immutable once written
- **Code Refactoring**: Extracted snapshot fetching into a named `fetchSnapshot` function for better readability and reusability

## Implementation Details
- Buy-all profit data is filtered to exclude null entries before calculating statistics
- The batched fetching processes snapshots in groups of 25 to maintain reasonable concurrency while avoiding connection pool issues
- All formatting uses existing utility functions (`formatProfitPerArea`, `formatChange`) for consistency
- Styling follows the existing design system with terminal-themed colors and typography

https://claude.ai/code/session_016gk3Fg6UV7pz9hPq4C4CNM