### PR TITLE
Remove bases-ranking from nav; fix duplicate rows

### DIFF
--- a/app/api/bases-ranking/route.ts
+++ b/app/api/bases-ranking/route.ts
@@ -149,16 +149,27 @@ export async function GET() {
       });
     }
 
-    rows.sort((a, b) => {
+    // Deduplicate by username — multiple hashes in knownCompanies can map to
+    // the same username; keep whichever entry has the most bases.
+    const byUsername = new Map<string, BasesRankingRow>();
+    for (const row of rows) {
+      const existing = byUsername.get(row.username.toLowerCase());
+      if (!existing || row.bases > existing.bases) {
+        byUsername.set(row.username.toLowerCase(), row);
+      }
+    }
+    const deduped = Array.from(byUsername.values());
+
+    deduped.sort((a, b) => {
       if (a.daysPerBase === null && b.daysPerBase === null) return 0;
       if (a.daysPerBase === null) return 1;
       if (b.daysPerBase === null) return -1;
       return a.daysPerBase - b.daysPerBase;
     });
-    rows.forEach((r, i) => { r.rank = i + 1; });
+    deduped.forEach((r, i) => { r.rank = i + 1; });
 
     return NextResponse.json({
-      rows,
+      rows: deduped,
       snapshotDate: "May 2026",
       fioDataDate,
     } satisfies BasesRankingResponse);

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -18,7 +18,6 @@ export default function RootLayout({
           <a href="/best-recipes">Best Recipes</a>
           <a href="/best-recipes-history">Recipe History</a>
           <a href="/xit-converter">XIT Converter</a>
-          <a href="/bases-ranking">Bases Ranking</a>
         </nav>
         <main className="terminal-container">
           {children}


### PR DESCRIPTION
Multiple hashes in knownCompanies.json can resolve to the same username, producing duplicate rows that become visible when the min-bases filter changes. Deduplicate server-side by username, keeping the entry with the most bases.


Claude-Session: https://claude.ai/code/session_01Ue4ydQNVvg2DUvNRBUmxeK